### PR TITLE
Added custom formatting possibility

### DIFF
--- a/samples/AspNetCore/WebSample/Startup.cs
+++ b/samples/AspNetCore/WebSample/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Hosting;
+using System;
 
 namespace WebSample
 {
@@ -32,7 +33,9 @@ namespace WebSample
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             // Create a logging provider based on the configuration information passed through the appsettings.json
-            loggerFactory.AddAWSProvider(this.Configuration.GetAWSLoggingConfigSection());
+            // You can even provide your custom formatting.
+            loggerFactory.AddAWSProvider(this.Configuration.GetAWSLoggingConfigSection(), 
+                formatter: (logLevel, message, exception) => $"[{DateTime.UtcNow}] {logLevel}: {message}");
 
             // Create a logger instance from the loggerFactory
             var logger = loggerFactory.CreateLogger<Program>();

--- a/src/AWS.Logger.AspNetCore/AWSLogger.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLogger.cs
@@ -12,6 +12,7 @@ namespace AWS.Logger.AspNetCore
         private readonly string _categoryName;
         private readonly IAWSLoggerCore _core;
         private readonly Func<string, LogLevel, bool> _filter;
+        private readonly Func<LogLevel, object, Exception, string> _customFormatter;
 
         /// <summary>
         /// Construct an instance of AWSLogger
@@ -19,11 +20,13 @@ namespace AWS.Logger.AspNetCore
         /// <param name="categoryName">The category name for the logger which can be used for filtering.</param>
         /// <param name="core">The core logger that is used to send messages to AWS.</param>
         /// <param name="filter">Filter function that will only allow messages to be sent to AWS if it returns true. If the value is null all messages are sent.</param>
-        public AWSLogger(string categoryName, IAWSLoggerCore core, Func<string, LogLevel, bool> filter)
+        /// <param name="customFormatter">A custom formatter which accepts a LogLevel, a state, and an exception and returns the formatted log message.</param>
+        public AWSLogger(string categoryName, IAWSLoggerCore core, Func<string, LogLevel, bool> filter, Func<LogLevel, object, Exception, string> customFormatter = null)
         {
             _categoryName = categoryName;
             _core = core;
             _filter = filter;
+            _customFormatter = customFormatter;
         }
 
         /// <summary>
@@ -64,7 +67,7 @@ namespace AWS.Logger.AspNetCore
             {
                 return;
             }
-            var message = formatter(state, exception);
+            var message = _customFormatter != null ? _customFormatter(logLevel, state, exception) : formatter(state, exception);
             _core.AddMessage(message);
         }
 

--- a/src/AWS.Logger.AspNetCore/AWSLoggerFactoryExtensions.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerFactoryExtensions.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory"></param>
         /// <param name="config">Configuration on how to connect to AWS and how the log messages should be sent.</param>
+        /// <param name="formatter">A custom formatter which accepts a LogLevel, a state, and an exception and returns the formatted log message.</param>
         /// <returns></returns>
-        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfig config)
+        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfig config, Func<LogLevel, object, Exception, string> formatter = null)
         {
             // If config is null. Assuming the logger is being activated in a debug environment
             // and skip adding the provider. We don't want to prevent developers running their application
@@ -31,7 +32,7 @@ namespace Microsoft.Extensions.Logging
                 return factory;
             }
 
-            var provider = new AWSLoggerProvider(config);
+            var provider = new AWSLoggerProvider(config, formatter);
             factory.AddProvider(provider);
             return factory;
         }
@@ -41,8 +42,9 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory"></param>
         /// <param name="configSection">Configuration and loglevels on how to connect to AWS and how the log messages should be sent.</param>
+        /// <param name="formatter">A custom formatter which accepts a LogLevel, a state, and an exception and returns the formatted log message.</param>
         /// <returns></returns>
-        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfigSection configSection)
+        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfigSection configSection, Func<LogLevel, object, Exception, string> formatter = null)
         {
             // If configSection is null. Assuming the logger is being activated in a debug environment
             // and skip adding the provider. We don't want to prevent developers running their application
@@ -53,7 +55,7 @@ namespace Microsoft.Extensions.Logging
                 return factory;
             }
 
-            var provider = new AWSLoggerProvider(configSection);
+            var provider = new AWSLoggerProvider(configSection, formatter);
             factory.AddProvider(provider);
             return factory;
         }
@@ -67,7 +69,7 @@ namespace Microsoft.Extensions.Logging
         /// <returns></returns>
         public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfig config, LogLevel minLevel)
         {
-            var provider = new AWSLoggerProvider(config,minLevel);
+            var provider = new AWSLoggerProvider(config, minLevel);
             factory.AddProvider(provider);
             return factory;
         }

--- a/test/AWS.Logger.AspNetCore.Tests/TestFormatter.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestFormatter.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AWS.Logger.AspNetCore.Tests
+{
+    public class TestFormatter
+    {
+        [Theory]
+        [InlineData("my log message", LogLevel.Trace)]
+        [InlineData("my log message", LogLevel.Debug)]
+        [InlineData("my log message", LogLevel.Critical)]
+        public void CustomFormatter_Must_Be_Applied(string message, LogLevel logLevel)
+        {
+            Func<LogLevel, object, Exception, string> customFormatter 
+                = (level, state, ex) => level + "hello world" + state.ToString();
+
+            Func<string, LogLevel, bool> filter = (categoryName, level) => true;
+
+            var coreLogger = new FakeCoreLogger();
+
+            var logger = new AWSLogger("TestCategory", coreLogger, filter, customFormatter);
+
+            logger.Log(logLevel, 0, message, null, (state, ex) => state.ToString());
+
+            string expectedMessage = customFormatter(logLevel, message, null);
+
+            Assert.Equal(expectedMessage, coreLogger.ReceivedMessages.First());
+        }
+    }
+}


### PR DESCRIPTION
Hi Spati2 & Norm & AWS Dev Team,

First of all, thank you for this great library. We just started to use it and it's great.

Although we are missing a functionality. For us, it's very important that we need to be able to customize the messages. For example: we need to have a transaction id injected to every one of our messages, and we want to see the LogLevel as well. This is very important to us, and this can be solved if we can provide our own formatter. Currently, unfortunately that is not possible.

ASP.NET Core (Kestrel, EF etc.) internally uses LogDebug, LogInformation, LogTrace etc. overloads of ILogger where the default formatter is getting applied. We want to format even the ASPNET Core internal logging messages, so in order to achieve this, the Log() overload needs to be customized like I did.

Thank you!
Peter