### PR TITLE
Decoupled IAmazonCloudWatchLogs from ASP.NET Core logging provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ The configuration is setup in the [appsettings.json](/samples/AspNetCore/WebSamp
 
 ```json
 "AWS.Logging": {
-  "Region": "us-east-1",
   "LogGroup": "AspNetCore.WebSample",
   "LogLevel": {
     "Default": "Debug",
@@ -161,6 +160,7 @@ public Startup(IHostingEnvironment env)
         .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
         .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
         .AddEnvironmentVariables();
+		
     Configuration = builder.Build();
 }
 ```
@@ -169,11 +169,19 @@ The `Configure` method is used to configure the services added to the dependency
 log providers are configured. For the `AWS.Logger.AspNetCore` the configuration for the provider is loaded from 
 the Configuration property and the AWS provider is added to the `ILoggerFactory`.
 
+The AWS provider expects an IAmazonCloudWatchLogs client which can be supplied configuring AWS SDK as explained in
+[Configuring the AWS SDK for .NET with .NET Core](http://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-netcore.html).
+
+After that, a client can be injected to the log provider as shown below:
+
 ```csharp
 public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
 {
     // Create a logging provider based on the configuration information passed through the appsettings.json
-    loggerFactory.AddAWSProvider(this.Configuration.GetAWSLoggingConfigSection());
+	// using the injected IAmazonCloudWatchLogs client implementation
+    loggerFactory.AddAWSProvider(Configuration.GetAWSOptions().CreateServiceClient<IAmazonCloudWatchLogs>(), Configuration.GetAWSLoggingConfigSection());
 
     ...
 ```
+
+All credential information is managed by the AWS SDK and automatically supplied to the IAmazonCloudWatchLogs client. Check the documentation specified above for more information.

--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -10,15 +10,16 @@ namespace Microsoft.Extensions.Configuration
         //Customer's information will be fetched from this block unless otherwise set.
         const string DEFAULT_BLOCK = "AWS.Logging";
 
-
         public static AWSLoggerConfigSection GetAWSLoggingConfigSection(this IConfiguration configSection, string configSectionInfoBlockName = DEFAULT_BLOCK)
         {
             var loggerConfigSection = configSection.GetSection(configSectionInfoBlockName);
             AWSLoggerConfigSection configObj = null;
+
             if (loggerConfigSection[AWSLoggerConfigSection.LOG_GROUP] != null)
             {
                 configObj = new AWSLoggerConfigSection(loggerConfigSection);
             }
+
             return configObj;
         }
     }
@@ -33,7 +34,8 @@ namespace Microsoft.Extensions.Configuration
         public IConfiguration LogLevels { get; set; } = null;
 
         internal const string LOG_GROUP = "LogGroup";
-        internal const string REGION = "Region";
+        internal const string CHECK_LOG_GROUP_EXISTANCE = "CheckLogGroupExistance";
+        internal const string LOG_STREAM = "LogStream";
         internal const string BATCH_PUSH_INTERVAL = "BatchPushInterval";
         internal const string BATCH_PUSH_SIZE_IN_BYTES = "BatchPushSizeInBytes";
         internal const string LOG_LEVEL = "LogLevel";
@@ -44,34 +46,47 @@ namespace Microsoft.Extensions.Configuration
         public AWSLoggerConfigSection(IConfiguration loggerConfigSection)
         {
             Config.LogGroup = loggerConfigSection[LOG_GROUP];
-            if (loggerConfigSection[REGION] != null)
+
+            if (loggerConfigSection[CHECK_LOG_GROUP_EXISTANCE] != null)
             {
-                Config.Region = loggerConfigSection[REGION];
+                Config.CheckLogGroupExistance = Boolean.Parse(loggerConfigSection[CHECK_LOG_GROUP_EXISTANCE]);
             }
+
+            if (loggerConfigSection[LOG_STREAM] != null)
+            {
+                Config.LogStream = loggerConfigSection[LOG_STREAM];
+            }
+
             if (loggerConfigSection[BATCH_PUSH_INTERVAL] != null)
             {
                 Config.BatchPushInterval = TimeSpan.FromMilliseconds(Int32.Parse(loggerConfigSection[BATCH_PUSH_INTERVAL]));
             }
+
             if (loggerConfigSection[BATCH_PUSH_SIZE_IN_BYTES] != null)
             {
                 Config.BatchSizeInBytes = Int32.Parse(loggerConfigSection[BATCH_PUSH_SIZE_IN_BYTES]);
             }
+
             if (loggerConfigSection[MAX_QUEUED_MESSAGES] != null)
             {
                 Config.MaxQueuedMessages = Int32.Parse(loggerConfigSection[MAX_QUEUED_MESSAGES]);
             }
+
             if (loggerConfigSection[LOG_STREAM_NAME_SUFFIX] != null)
             {
                 Config.LogStreamNameSuffix = loggerConfigSection[LOG_STREAM_NAME_SUFFIX];
             }
+
             if (loggerConfigSection[LIBRARY_LOG_FILE_NAME] != null)
             {
                 Config.LibraryLogFileName = loggerConfigSection[LIBRARY_LOG_FILE_NAME];
             }
+
             var logLevels = loggerConfigSection.GetSection(LOG_LEVEL);
+
             if (logLevels != null && logLevels.GetChildren().Count() > 0)
             {
-                this.LogLevels = logLevels;
+                LogLevels = logLevels;
             }
         }
     }

--- a/src/AWS.Logger.AspNetCore/AWSLoggerFactoryExtensions.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerFactoryExtensions.cs
@@ -1,11 +1,11 @@
-﻿using AWS.Logger;
+﻿using Amazon.CloudWatchLogs;
+using AWS.Logger;
 using AWS.Logger.AspNetCore;
 using Microsoft.Extensions.Configuration;
 using System;
 #if CORECLR
 using System.Runtime.Loader;
 #endif
-using System.Reflection;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory"></param>
         /// <param name="config">Configuration on how to connect to AWS and how the log messages should be sent.</param>
         /// <returns></returns>
-        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfig config)
+        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, IAmazonCloudWatchLogs client, AWSLoggerConfig config)
         {
             // If config is null. Assuming the logger is being activated in a debug environment
             // and skip adding the provider. We don't want to prevent developers running their application
@@ -31,8 +31,10 @@ namespace Microsoft.Extensions.Logging
                 return factory;
             }
 
-            var provider = new AWSLoggerProvider(config);
+            var provider = new AWSLoggerProvider(client, config);
+
             factory.AddProvider(provider);
+
             return factory;
         }
 
@@ -42,7 +44,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory"></param>
         /// <param name="configSection">Configuration and loglevels on how to connect to AWS and how the log messages should be sent.</param>
         /// <returns></returns>
-        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfigSection configSection)
+        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, IAmazonCloudWatchLogs client, AWSLoggerConfigSection configSection)
         {
             // If configSection is null. Assuming the logger is being activated in a debug environment
             // and skip adding the provider. We don't want to prevent developers running their application
@@ -50,11 +52,14 @@ namespace Microsoft.Extensions.Logging
             if (configSection == null)
             {
                 factory.CreateLogger("AWS.Logging.AspNetCore").LogWarning("AWSLoggerConfigSection is null. LogGroup is likely not configured in config files. Skipping adding AWS Logging provider.");
+
                 return factory;
             }
 
-            var provider = new AWSLoggerProvider(configSection);
+            var provider = new AWSLoggerProvider(client, configSection);
+
             factory.AddProvider(provider);
+
             return factory;
         }
 
@@ -65,10 +70,12 @@ namespace Microsoft.Extensions.Logging
         /// <param name="config">Configuration on how to connect to AWS and how the log messages should be sent.</param>
         /// <param name="minLevel">The minimum log level for messages to be written.</param>
         /// <returns></returns>
-        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfig config, LogLevel minLevel)
+        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, IAmazonCloudWatchLogs client, AWSLoggerConfig config, LogLevel minLevel)
         {
-            var provider = new AWSLoggerProvider(config,minLevel);
+            var provider = new AWSLoggerProvider(client, config, minLevel);
+
             factory.AddProvider(provider);
+
             return factory;
         }
 
@@ -79,10 +86,12 @@ namespace Microsoft.Extensions.Logging
         /// <param name="config">Configuration on how to connect to AWS and how the log messages should be sent.</param>
         /// <param name="filter">A filter function that has the logger category name and log level which can be used to filter messages being sent to AWS.</param>
         /// <returns></returns>
-        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, AWSLoggerConfig config, Func<string, LogLevel, bool> filter)
+        public static ILoggerFactory AddAWSProvider(this ILoggerFactory factory, IAmazonCloudWatchLogs client, AWSLoggerConfig config, Func<string, LogLevel, bool> filter)
         {
-            var provider = new AWSLoggerProvider(config, filter);
+            var provider = new AWSLoggerProvider(client, config, filter);
+
             factory.AddProvider(provider);
+
             return factory;
         }
     }

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -1,19 +1,11 @@
 ﻿using System;
 
-using Amazon.Runtime;
 namespace AWS.Logger
 {
     /// <summary>
     /// This class contains all the configuration options for logging messages to AWS. As messages from the application are 
     /// sent to the logger they are queued up in a batch. The batch will be sent when either BatchPushInterval or BatchSizeInBytes
     /// are exceeded.
-    /// 
-    /// <para>
-    /// AWS Credentials are determined using the following steps.
-    /// 1) If the Credentials property is set
-    /// 2) If the Profile property is set and the can be found
-    /// 3) Use the AWS SDK for .NET fall back mechanism to find enviroment credentials.
-    /// </para>
     /// </summary>
     public class AWSLoggerConfig : IAWSLoggerConfig
     {
@@ -26,37 +18,19 @@ namespace AWS.Logger
         public string LogGroup { get; set; }
 
         /// <summary>
-        /// Gets and sets the Profile property. The profile is used to look up AWS credentials in the profile store.
+        /// Gets the CheckLogGroupExistance property. If this is set to True, some checks are
+        /// performed to ensure that the specified LogGroup exists. If not, the LogGroup is created.
         /// <para>
-        /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
+        /// The default is False.
         /// </para>
         /// </summary>
-        public string Profile { get; set; }
+        public bool CheckLogGroupExistance { get; set; } = false;
 
         /// <summary>
-        /// Gets and sets the ProfilesLocation property. If this is not set the default profile store is used by the AWS SDK for .NET 
-        /// to look up credentials. This is most commonly used when you are running an application of on-priemse under a service account.
-        /// <para>
-        /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
-        /// </para>
+        /// Gets the LogStream property. This is the name of the CloudWatch Logs stream within the
+        /// specified LogGroup. If a LogStream is not specified, one gets created automatically.
         /// </summary>
-        public string ProfilesLocation { get; set; }
-
-        /// <summary>
-        /// Gets and sets the Credentials property. These are the AWS credentials used by the AWS SDK for .NET to make service calls.
-        /// <para>
-        /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
-        /// </para>
-        /// </summary>
-        public AWSCredentials Credentials { get; set; }
-
-
-        /// <summary>
-        /// Gets and sets the Region property. This is the AWS Region that will be used for CloudWatch Logs. If this is not
-        /// the AWS SDK for .NET will use its fall back logic to try and determine the region through environment variables and EC2 instance metadata.
-        /// If the Region is not set and no region is found by the SDK's fall back logic then an exception will be thrown.
-        /// </summary>
-        public string Region { get; set; }
+        public string LogStream { get; set; }
 
         /// <summary>
         /// Gets and sets the BatchPushInterval property. For performance the log messages are sent to AWS in batch sizes. BatchPushInterval 
@@ -98,9 +72,7 @@ namespace AWS.Logger
         /// <summary>
         /// Default Constructor
         /// </summary>
-        public AWSLoggerConfig()
-        {
-        }
+        public AWSLoggerConfig() { }
 
         /// <summary>
         /// Construct instance and sets the LogGroup

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Amazon.Runtime;
 
 namespace AWS.Logger
 {
@@ -12,37 +11,16 @@ namespace AWS.Logger
         string LogGroup { get; }
 
         /// <summary>
-        /// Gets the Profile property. The profile is used to look up AWS credentials in the profile store.
-        /// <para>
-        /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
-        /// </para>
+        /// Gets the CheckLogGroupExistance property. If this is set to True, some checks are
+        /// performed to ensure that the specified LogGroup exists. If not, the LogGroup is created.
         /// </summary>
-        string Profile { get;  }
+        bool CheckLogGroupExistance { get; }
 
         /// <summary>
-        /// Gets the ProfilesLocation property. If this is not set the default profile store is used by the AWS SDK for .NET 
-        /// to look up credentials. This is most commonly used when you are running an application of on-priemse under a service account.
-        /// <para>
-        /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
-        /// </para>
+        /// Gets the LogStream property. This is the name of the CloudWatch Logs stream within the
+        /// specified LogGroup. If a LogStream is not specified, one gets created automatically.
         /// </summary>
-        string ProfilesLocation { get;  }
-
-        /// <summary>
-        /// Gets the Credentials property. These are the AWS credentials used by the AWS SDK for .NET to make service calls.
-        /// <para>
-        /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
-        /// </para>
-        /// </summary>
-        AWSCredentials Credentials { get;  }
-
-
-        /// <summary>
-        /// Gets the Region property. This is the AWS Region that will be used for CloudWatch Logs. If this is not
-        /// the AWS SDK for .NET will use its fall back logic to try and determine the region through environment variables and EC2 instance metadata.
-        /// If the Region is not set and no region is found by the SDK's fall back logic then an exception will be thrown.
-        /// </summary>
-        string Region { get;  }
+        string LogStream { get; }
 
         /// <summary>
         /// Gets the BatchPushInterval property. For performance the log messages are sent to AWS in batch sizes. BatchPushInterval 


### PR DESCRIPTION
I made the changes to decouple the creation of the IAmazonCloudWatchLogs client from the logging provider in order to address issue #16.

Now the client can be provided by DI facilities specified in [Configuring the AWS SDK for .NET with .NET Core](http://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-netcore.html) and all credential information is no longer needed by the logging provider.

Also added a couple of extra options:

- First one is to control whether the library should check LogGroup existance or not. By default it assumes the LogGroup exists instead of listing existing ones and creating the group if not found.
I did this in order to better control permissions over the log groups as listing and creating them required more permissions. If we assume that the LogGroup exists, it is possible to limit permission to the specific LogGroup resource.
- Another option added is LogStream which allow the user to specify the LogStream instead of creating a new one. If no LogStream is specified, a new one is created as per the current implementation.