### PR TITLE
Prevent NRE in finalizer

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -143,7 +143,10 @@ namespace AWS.Logger.Core
 
         ~AWSLoggerCore()
         {
-            _cancelStartSource.Dispose();
+            if (_cancelStartSource != null)
+            {
+                _cancelStartSource.Dispose();
+            }
         }
         /// <summary>
         /// Kicks off the Poller Thread to keep tabs on the PutLogEvent request and the


### PR DESCRIPTION
If there's an exception in `AWSLoggerCore` constructor (wrong credentials, AWS not available, etc) then `_cancelStartSource` may stay undefined and break .NET CLR Finalizer thread