### PR TITLE
Add ITextFormatter to Serilog plugin so can format messages

### DIFF
--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -29,8 +29,9 @@ namespace AWS.Logger.SeriLog
         /// <returns></returns>
         public static LoggerConfiguration AWSSeriLog(
                   this LoggerSinkConfiguration loggerConfiguration,
-                  ITextFormatter textFormatter,
-                  IConfiguration configuration)
+                  IConfiguration configuration, 
+                  IFormatProvider iFormatProvider = null,
+                  ITextFormatter textFormatter = null )
         {
             AWSLoggerConfig config = new AWSLoggerConfig();
 
@@ -63,8 +64,10 @@ namespace AWS.Logger.SeriLog
             {
                 config.LibraryLogFileName = configuration[LIBRARY_LOG_FILE_NAME];
             }
-            return AWSSeriLog(loggerConfiguration, textFormatter, config);
+            return AWSSeriLog(loggerConfiguration, config, iFormatProvider, textFormatter);
         }
+
+
         /// <summary>
         /// AWSSeriLogger target that is called when the customer
         /// explicitly creates a configuration of type AWSLoggerConfig 
@@ -75,11 +78,11 @@ namespace AWS.Logger.SeriLog
         /// <returns></returns>
         public static LoggerConfiguration AWSSeriLog(
                   this LoggerSinkConfiguration loggerConfiguration,
-                   ITextFormatter textFormatter,
-                  AWSLoggerConfig configuration = null)
+                   AWSLoggerConfig configuration = null,
+                   IFormatProvider iFormatProvider = null, 
+                   ITextFormatter textFormatter = null)
         {
-            if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
-            return loggerConfiguration.Sink(new AWSSink(configuration, textFormatter));
+            return loggerConfiguration.Sink(new AWSSink(configuration, iFormatProvider, textFormatter));
         }
     }
 }

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -1,4 +1,5 @@
 ﻿using Serilog;
+using Serilog.Formatting;
 using Serilog.Configuration;
 using System;
 using System.Collections.Generic;
@@ -28,6 +29,7 @@ namespace AWS.Logger.SeriLog
         /// <returns></returns>
         public static LoggerConfiguration AWSSeriLog(
                   this LoggerSinkConfiguration loggerConfiguration,
+                  ITextFormatter textFormatter,
                   IConfiguration configuration)
         {
             AWSLoggerConfig config = new AWSLoggerConfig();
@@ -61,7 +63,7 @@ namespace AWS.Logger.SeriLog
             {
                 config.LibraryLogFileName = configuration[LIBRARY_LOG_FILE_NAME];
             }
-            return AWSSeriLog(loggerConfiguration, config);
+            return AWSSeriLog(loggerConfiguration, textFormatter, config);
         }
         /// <summary>
         /// AWSSeriLogger target that is called when the customer
@@ -73,9 +75,11 @@ namespace AWS.Logger.SeriLog
         /// <returns></returns>
         public static LoggerConfiguration AWSSeriLog(
                   this LoggerSinkConfiguration loggerConfiguration,
+                   ITextFormatter textFormatter,
                   AWSLoggerConfig configuration = null)
         {
-            return loggerConfiguration.Sink(new AWSSink(configuration));
+            if (textFormatter == null) throw new ArgumentNullException(nameof(textFormatter));
+            return loggerConfiguration.Sink(new AWSSink(configuration, textFormatter));
         }
     }
 }

--- a/src/AWS.Logger.SeriLog/Properties/AssemblyInfo.cs
+++ b/src/AWS.Logger.SeriLog/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.2")]
+[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.0")]

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/test/AWS.Logger.SeriLog.Tests/SeriLoggerTestClass.cs
+++ b/test/AWS.Logger.SeriLog.Tests/SeriLoggerTestClass.cs
@@ -1,6 +1,7 @@
 ﻿using AWS.Logger.TestUtils;
 using Microsoft.Extensions.Configuration;
 using Serilog;
+using Serilog.Formatting.Compact;
 using System;
 using System.Threading;
 using Xunit;
@@ -22,10 +23,10 @@ namespace AWS.Logger.SeriLog.Tests
             var configuration = new ConfigurationBuilder()
             .AddJsonFile(configurationFile)
             .Build();
-
+             
             Log.Logger = new LoggerConfiguration().
                 ReadFrom.Configuration(configuration).
-                 WriteTo.AWSSeriLog(configuration).CreateLogger();
+                 WriteTo.AWSSeriLog(new CompactJsonFormatter(), configuration).CreateLogger();
         }
         #region Test Cases  
 

--- a/test/AWS.Logger.SeriLog.Tests/SeriLoggerTestClass.cs
+++ b/test/AWS.Logger.SeriLog.Tests/SeriLoggerTestClass.cs
@@ -26,7 +26,7 @@ namespace AWS.Logger.SeriLog.Tests
              
             Log.Logger = new LoggerConfiguration().
                 ReadFrom.Configuration(configuration).
-                 WriteTo.AWSSeriLog(new CompactJsonFormatter(), configuration).CreateLogger();
+                 WriteTo.AWSSeriLog( configuration).CreateLogger();
         }
         #region Test Cases  
 


### PR DESCRIPTION
replaced IFormatProvider with ITextFormatter. The implementation is borrowed from Serilog.Sinks.AwsCloudWatch