### PR TITLE
Implemented aws/aws-logging-dotnet#44

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWSLogScope.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLogScope.cs
@@ -1,0 +1,49 @@
+﻿namespace AWS.Logger.AspNetCore
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+
+    [DebuggerDisplay("{" + nameof(CategoryName) + " == null ? \"\" : \"[" + nameof(CategoryName) + "] \",nq}{" + nameof(ToString) + ",nq}")]
+    public class AWSLogScope
+    {
+        private static readonly AsyncLocal<AWSLogScope> Instance = new AsyncLocal<AWSLogScope>();
+
+        public string CategoryName { get; }
+        public object State { get; }
+
+        internal AWSLogScope(string categoryName, object state)
+        {
+            CategoryName = categoryName;
+            State = state;
+        }
+
+        public AWSLogScope Parent { get; private set; }
+
+        public static AWSLogScope Current
+        {
+            set => Instance.Value = value;
+            get => Instance.Value;
+        }
+
+        public static IDisposable Push(string name, object state)
+        {
+            var current = Current;
+            Current = new AWSLogScope(name, state) {Parent = current};
+            return new DisposableScope();
+        }
+
+        public override string ToString()
+        {
+            return State?.ToString();
+        }
+
+        private class DisposableScope : IDisposable
+        {
+            public void Dispose()
+            {
+                Current = Current.Parent;
+            }
+        }
+    }
+}

--- a/src/AWS.Logger.AspNetCore/AWSLogger.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLogger.cs
@@ -15,6 +15,8 @@ namespace AWS.Logger.AspNetCore
         private readonly Func<string, LogLevel, bool> _filter;
         private readonly Func<LogLevel, object, Exception, string> _customFormatter;
 
+        public bool IncludeScopes { get; set; }
+
         /// <summary>
         /// Construct an instance of AWSLogger
         /// </summary>
@@ -30,15 +32,12 @@ namespace AWS.Logger.AspNetCore
             _customFormatter = customFormatter;
         }
 
-        /// <summary>
-        /// Currently scopes are not supported and a dummy instance of IDisposable is returned but not used.
-        /// </summary>
-        /// <typeparam name="TState"></typeparam>
-        /// <param name="state"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public IDisposable BeginScope<TState>(TState state)
         {
-            return new DisposableScope();
+            if (state == null)
+                throw new ArgumentNullException(nameof(state));
+            return AWSLogScope.Push(_categoryName, state);
         }
 
         /// <summary>
@@ -64,13 +63,31 @@ namespace AWS.Logger.AspNetCore
         /// <param name="formatter"></param>
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            StringBuilder formattedMessage = null;
             if (!IsEnabled(logLevel))
-            {
                 return;
+
+            string message;
+            if (_customFormatter == null)
+            {
+                if (formatter == null)
+                    throw new ArgumentNullException(nameof(formatter));
+                message = formatter(state, exception);
             }
-            var message = _customFormatter != null ? _customFormatter(logLevel, state, exception) : formatter(state, exception);
-            formattedMessage = new StringBuilder();
+            else
+            {
+                message = _customFormatter(logLevel, state, exception);
+            }
+
+            if (string.IsNullOrEmpty(message) && exception == null)
+                // If neither a message nor an exception are provided, don't log anything (there's nothing to log, after all).
+                return;
+
+            // Build actual message
+            var formattedMessage = new StringBuilder();
+
+            if (IncludeScopes)
+                AddScopeInformation(formattedMessage);
+
             formattedMessage.AppendLine(message);
             if (exception != null && _customFormatter==null)
             {
@@ -80,12 +97,23 @@ namespace AWS.Logger.AspNetCore
 
         }
 
-        private class DisposableScope : IDisposable
+        private static void AddScopeInformation(StringBuilder sb)
         {
-            public void Dispose()
-            {
+            var deepestScope = AWSLogScope.Current;
+            var current = deepestScope;
 
+            while (current != null)
+            {
+                var scopeLog = $"=> {current}";
+                sb.Insert(0, scopeLog);
+
+                current = current.Parent;
+                if (current != null)
+                    sb.Insert(0, " ");
             }
+
+            if (deepestScope != null)
+                sb.Append(": ");
         }
     }
 }

--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Extensions.Configuration
         internal const string MAX_QUEUED_MESSAGES = "MaxQueuedMessages";
         internal const string LOG_STREAM_NAME_SUFFIX = "LogStreamNameSuffix";
         internal const string LIBRARY_LOG_FILE_NAME = "LibraryLogFileName";
+        internal const string INCLUDE_SCOPES_NAME = "IncludeScopes";
 
         public AWSLoggerConfigSection(IConfiguration loggerConfigSection)
         {
@@ -72,6 +73,10 @@ namespace Microsoft.Extensions.Configuration
             if (loggerConfigSection[LIBRARY_LOG_FILE_NAME] != null)
             {
                 Config.LibraryLogFileName = loggerConfigSection[LIBRARY_LOG_FILE_NAME];
+            }
+            if (loggerConfigSection[INCLUDE_SCOPES_NAME] != null)
+            {
+                Config.IncludeScopes = Boolean.Parse(loggerConfigSection[INCLUDE_SCOPES_NAME]);
             }
             var logLevels = loggerConfigSection.GetSection(LOG_LEVEL);
             if (logLevels != null && logLevels.GetChildren().Count() > 0)

--- a/src/AWS.Logger.AspNetCore/AWSLoggerProvider.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerProvider.cs
@@ -11,10 +11,10 @@ namespace AWS.Logger.AspNetCore
     /// </summary>
     public class AWSLoggerProvider : ILoggerProvider
     {       
-        private IAWSLoggerCore _core;
+        private readonly IAWSLoggerCore _core;
+        private readonly AWSLoggerConfigSection _configSection;
+        private readonly Func<LogLevel, object, Exception, string> _customFormatter;
         private Func<string, LogLevel, bool> _filter;
-        private AWSLoggerConfigSection _configSection;
-        private Func<LogLevel, object, Exception, string> _customFormatter;
 
         /// <summary>
         /// Creates the logging provider with the configuration information to connect to AWS and how the messages should be sent.

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -93,6 +93,33 @@ namespace AWS.Logger
         /// </para>
         /// </summary>
         internal TimeSpan MonitorSleepTime = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
+        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of a DateTimeStamp as the prefix and a user defined suffix value that can 
+        /// be set using the LogStreamNameSuffix property defined here.
+        /// The LogstreamName then follows the pattern '[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogstreamNameSuffix]'
+        /// <para>
+        /// The default is going to a Guid.
+        /// </para>
+        /// </summary>
+        public string LogStreamNameSuffix { get; set; } = Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
+        /// <para>
+        /// The default is "aws-logger-errors.txt".
+        /// </para>
+        /// </summary>
+        public string LibraryLogFileName { get; set; } = "aws-logger-errors.txt";
+
+        /// <summary>
+        /// Gets the <see cref="IAWSLoggerConfig.IncludeScopes"/> property. This determines if scopes - if they exist - are included in a log message.
+        /// <para>
+        /// The default is false.
+        /// </para>
+        /// </summary>
+        public bool IncludeScopes { get; set; } = false;
+
         #endregion
 
         /// <summary>
@@ -116,23 +143,5 @@ namespace AWS.Logger
             MonitorSleepTime = TimeSpan.FromMilliseconds(0);
             BatchPushInterval = TimeSpan.FromSeconds(0);
         }
-
-        /// <summary>
-        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of a DateTimeStamp as the prefix and a user defined suffix value that can 
-        /// be set using the LogStreamNameSuffix property defined here.
-        /// The LogstreamName then follows the pattern '[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogstreamNameSuffix]'
-        /// <para>
-        /// The default is going to a Guid.
-        /// </para>
-        /// </summary>
-        public string LogStreamNameSuffix { get; set; } = Guid.NewGuid().ToString();
-
-        /// <summary>
-        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
-        /// <para>
-        /// The default is "aws-logger-errors.txt".
-        /// </para>
-        /// </summary>
-        public string LibraryLogFileName { get; set; } = "aws-logger-errors.txt";
     }
 }

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -87,5 +87,13 @@ namespace AWS.Logger
         /// </para>
         /// </summary>
         string LibraryLogFileName { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IAWSLoggerConfig.IncludeScopes"/> property. This determines if scopes - if they exist - are included in a log message.
+        /// <para>
+        /// The default is false.
+        /// </para>
+        /// </summary>
+        bool IncludeScopes { get; set; }
     }
 }

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -30,8 +30,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public string LogGroup
         {
-            get { return _config.LogGroup; }
-            set { _config.LogGroup = value; }
+            get => _config.LogGroup;
+            set => _config.LogGroup = value;
         }
 
         /// <summary>
@@ -42,8 +42,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public string Profile
         {
-            get { return _config.Profile; }
-            set { _config.Profile = value; }
+            get => _config.Profile;
+            set => _config.Profile = value;
         }
 
 
@@ -56,8 +56,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public string ProfilesLocation
         {
-            get { return _config.ProfilesLocation; }
-            set { _config.ProfilesLocation = value; }
+            get => _config.ProfilesLocation;
+            set => _config.ProfilesLocation = value;
         }
 
 
@@ -69,8 +69,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public AWSCredentials Credentials
         {
-            get { return _config.Credentials; }
-            set { _config.Credentials = value; }
+            get => _config.Credentials;
+            set => _config.Credentials = value;
         }
 
 
@@ -81,8 +81,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public string Region
         {
-            get { return _config.Region; }
-            set { _config.Region = value; }
+            get => _config.Region;
+            set => _config.Region = value;
         }
 
 
@@ -95,8 +95,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public TimeSpan BatchPushInterval
         {
-            get { return _config.BatchPushInterval; }
-            set { _config.BatchPushInterval = value; }
+            get => _config.BatchPushInterval;
+            set => _config.BatchPushInterval = value;
         }
 
 
@@ -109,8 +109,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public int BatchSizeInBytes
         {
-            get { return _config.BatchSizeInBytes; }
-            set { _config.BatchSizeInBytes = value; }
+            get => _config.BatchSizeInBytes;
+            set => _config.BatchSizeInBytes = value;
         }
 
 
@@ -123,8 +123,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public int MaxQueuedMessages
         {
-            get { return _config.MaxQueuedMessages; }
-            set { _config.MaxQueuedMessages = value; }
+            get => _config.MaxQueuedMessages;
+            set => _config.MaxQueuedMessages = value;
         }
 
         /// <summary>
@@ -136,8 +136,8 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public string LogStreamNameSuffix
         {
-            get { return _config.LogStreamNameSuffix; }
-            set { _config.LogStreamNameSuffix = value; }
+            get => _config.LogStreamNameSuffix;
+            set => _config.LogStreamNameSuffix = value;
         }
 
         /// <summary>
@@ -148,8 +148,20 @@ namespace AWS.Logger.Log4net
         /// </summary>
         public string LibraryLogFileName
         {
-            get { return _config.LibraryLogFileName; }
-            set { _config.LibraryLogFileName = value; }
+            get => _config.LibraryLogFileName;
+            set => _config.LibraryLogFileName = value;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IAWSLoggerConfig.IncludeScopes"/> property. This determines if scopes - if they exist - are included in a log message.
+        /// <para>
+        /// The default is false.
+        /// </para>
+        /// </summary>
+        public bool IncludeScopes
+        {
+            get => _config.IncludeScopes;
+            set => _config.IncludeScopes = value;
         }
 
         /// <summary>
@@ -173,7 +185,8 @@ namespace AWS.Logger.Log4net
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
 				LogStreamNameSuffix = LogStreamNameSuffix,
-				LibraryLogFileName = LibraryLogFileName
+				LibraryLogFileName = LibraryLogFileName,
+                IncludeScopes = IncludeScopes
             };
             _core = new AWSLoggerCore(config, "Log4net");
         }

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -34,8 +34,8 @@ namespace NLog.AWS.Logger
         [RequiredParameter]
         public string LogGroup
         {
-            get { return _config.LogGroup; }
-            set { _config.LogGroup = value; }
+            get => _config.LogGroup;
+            set => _config.LogGroup = value;
         }
 
         /// <summary>
@@ -46,8 +46,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public string Profile
         {
-            get { return _config.Profile; }
-            set { _config.Profile = value; }
+            get => _config.Profile;
+            set => _config.Profile = value;
         }
 
 
@@ -60,8 +60,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public string ProfilesLocation
         {
-            get { return _config.ProfilesLocation; }
-            set { _config.ProfilesLocation = value; }
+            get => _config.ProfilesLocation;
+            set => _config.ProfilesLocation = value;
         }
 
 
@@ -73,8 +73,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public AWSCredentials Credentials
         {
-            get { return _config.Credentials; }
-            set { _config.Credentials = value; }
+            get => _config.Credentials;
+            set => _config.Credentials = value;
         }
 
 
@@ -85,8 +85,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public string Region
         {
-            get { return _config.Region; }
-            set { _config.Region = value; }
+            get => _config.Region;
+            set => _config.Region = value;
         }
 
 
@@ -99,8 +99,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public TimeSpan BatchPushInterval
         {
-            get { return _config.BatchPushInterval; }
-            set { _config.BatchPushInterval = value; }
+            get => _config.BatchPushInterval;
+            set => _config.BatchPushInterval = value;
         }
 
 
@@ -113,8 +113,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public int BatchSizeInBytes
         {
-            get { return _config.BatchSizeInBytes; }
-            set { _config.BatchSizeInBytes = value; }
+            get => _config.BatchSizeInBytes;
+            set => _config.BatchSizeInBytes = value;
         }
 
         /// <summary>
@@ -126,8 +126,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public int MaxQueuedMessages
         {
-            get { return _config.MaxQueuedMessages; }
-            set { _config.MaxQueuedMessages = value; }
+            get => _config.MaxQueuedMessages;
+            set => _config.MaxQueuedMessages = value;
         }
 
         /// <summary>
@@ -139,8 +139,8 @@ namespace NLog.AWS.Logger
         /// </summary>
         public string LogStreamNameSuffix
         {
-            get { return _config.LogStreamNameSuffix; }
-            set { _config.LogStreamNameSuffix = value; }
+            get => _config.LogStreamNameSuffix;
+            set => _config.LogStreamNameSuffix = value;
         }
 
         /// <summary>
@@ -151,8 +151,20 @@ namespace NLog.AWS.Logger
         /// </summary>
         public string LibraryLogFileName
         {
-            get { return _config.LibraryLogFileName; }
-            set { _config.LibraryLogFileName = value; }
+            get => _config.LibraryLogFileName;
+            set => _config.LibraryLogFileName = value;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IAWSLoggerConfig.IncludeScopes"/> property. This determines if scopes - if they exist - are included in a log message.
+        /// <para>
+        /// The default is false.
+        /// </para>
+        /// </summary>
+        public bool IncludeScopes
+        {
+            get => _config.IncludeScopes;
+            set => _config.IncludeScopes = value;
         }
 
         protected override void InitializeTarget()
@@ -173,7 +185,8 @@ namespace NLog.AWS.Logger
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
 				LogStreamNameSuffix = LogStreamNameSuffix,
-				LibraryLogFileName = LibraryLogFileName
+				LibraryLogFileName = LibraryLogFileName,
+                IncludeScopes = IncludeScopes
             };
             _core = new AWSLoggerCore(config, "NLog");
         }

--- a/test/AWS.Logger.AspNetCore.Tests/TestFormatter.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestFormatter.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace AWS.Logger.AspNetCore.Tests

--- a/test/AWS.Logger.AspNetCore.Tests/TestScope.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestScope.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
+﻿using System.Linq;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -13,20 +9,89 @@ namespace AWS.Logger.AspNetCore.Tests
     public class TestScope
     {
         [Fact]
-        // Althrough scoping isn't currently supported make sure that at least it doesn't cause
-        // issues if it is used.
+        // Make sure that a message will be logged inside a scope, even when scopes are not included.
         public void MakeSureCanCreateScope()
         {
             var coreLogger = new FakeCoreLogger();
-            var logger = new AWSLogger("MakeSureCanCreateScope", coreLogger, null);
+            var logger = new AWSLogger("MakeSureCanCreateScope", coreLogger, null)
+            {
+                IncludeScopes = false
+            };
 
-            using (var scope = logger.BeginScope<TestScope>(this))
+            using (logger.BeginScope("Test Scope"))
             {
                 logger.LogInformation("log");
             }
 
             Assert.Equal(1, coreLogger.ReceivedMessages.Count);
-            Assert.True(coreLogger.ReceivedMessages.Contains("log\r\n"));
+            Assert.True(coreLogger.ReceivedMessages.Contains("log\r\n"), "Messages don't contain actual log message.");
+        }
+
+        [Fact]
+        // Make sure that a message will be logged outside a scope, even when scopes are included.
+        public void MakeSureCanLogWithoutScope()
+        {
+            var coreLogger = new FakeCoreLogger();
+            var logger = new AWSLogger("MakeSureCanCreateScope", coreLogger, null)
+            {
+                IncludeScopes = true
+            };
+
+            logger.LogInformation("log");
+
+            Assert.Equal(1, coreLogger.ReceivedMessages.Count);
+            var msg = coreLogger.ReceivedMessages.SingleOrDefault(m => m.Contains("log\r\n"));
+            Assert.True(msg != null, "Messages don't contain actual log message.");
+            Assert.False(msg.Contains("=>"), "Fragment of scopes exists (\"=>\").");
+            Assert.False(msg.Contains(": "), "Fragment of scopes exists (\": \").");
+        }
+
+        [Fact]
+        // Make sure that a message inside a scope will be logged together with the scope.
+        public void MakeSureScopeIsIncluded()
+        {
+            var coreLogger = new FakeCoreLogger();
+            var logger = new AWSLogger("MakeSureCanCreateScope", coreLogger, null)
+            {
+                IncludeScopes = true
+            };
+
+            using (logger.BeginScope("Test scope"))
+            {
+                logger.LogInformation("log");
+            }
+
+            Assert.Equal(1, coreLogger.ReceivedMessages.Count);
+            var msg = coreLogger.ReceivedMessages.SingleOrDefault(m => m.Contains("log\r\n"));
+            Assert.True(msg != null, "Messages don't contain actual log message.");
+            // Same message should contain the scope
+            Assert.True(msg.Contains("=> Test scope: "), "Scope is not included.");
+        }
+
+        [Fact]
+        // Make sure that a message inside multiple scopes will be logged together with the scopes.
+        public void MakeSureScopesAreIncluded()
+        {
+            var coreLogger = new FakeCoreLogger();
+            var logger = new AWSLogger("MakeSureCanCreateScope", coreLogger, null)
+            {
+                IncludeScopes = true
+            };
+
+            using (logger.BeginScope("Outer scope"))
+            {
+                using (logger.BeginScope("Inner scope"))
+                {
+                    logger.LogInformation("log");
+                }
+            }
+
+            Assert.Equal(1, coreLogger.ReceivedMessages.Count);
+            var msg = coreLogger.ReceivedMessages.SingleOrDefault(m => m.Contains("log\r\n"));
+            Assert.True(msg != null, "Messages don't contain actual log message.");
+            // Same message should contain the scope
+            Assert.True(msg.Contains("=> Outer scope"), "Outer scope is not included.");
+            Assert.True(msg.Contains("=> Inner scope: "), "Inner scope is not included.");
         }
     }
 }


### PR DESCRIPTION
*Issue #44 :

*Description of changes:*
- Implemented logic to support ILogger.BeginScope<T>
- Extended configuration with "IncludeScopes" property, as well as
reading the new configuration property
- Implemented test cases
- Some minor code clean-up in the configuration classes (getter and setter for readability) & tests (removed unused namespaces)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
