### PR TITLE
upgrade log4net for .NET Framework to version 2.0.8

### DIFF
--- a/samples/Log4net/ConfigExample/ConfigExample.csproj
+++ b/samples/Log4net/ConfigExample/ConfigExample.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/Log4net/ConfigExample/packages.config
+++ b/samples/Log4net/ConfigExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
 </packages>

--- a/samples/Log4net/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
+++ b/samples/Log4net/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/Log4net/ProgrammaticConfigurationExample/packages.config
+++ b/samples/Log4net/ProgrammaticConfigurationExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
 </packages>

--- a/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
+++ b/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
@@ -39,7 +39,7 @@
       <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
    <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
   
 </Project>

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -39,6 +39,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="log4net" Version="2.0.5" />
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION

*upgrade log4net for .NET framework to version 2.0.8*
Right now for .NET framework library, it still use log4net version 2.0.5 as an attached screenshot.
So, I updated it to use log4net version 2.0.8 which is the latest version of log4net.

![image](https://user-images.githubusercontent.com/2938310/46584506-65fc4b00-ca8e-11e8-853b-e5703d2729c4.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
