### PR TITLE
Example project of using log4net and AWS basic credentials

### DIFF
--- a/AWS.Logger.sln
+++ b/AWS.Logger.sln
@@ -21,7 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AspNetCore", "AspNetCore", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Log4net", "Log4net", "{D28DFB15-FA6F-42EE-890C-E6300A187CCA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWS.Logger.Log4net", "src\AWS.Logger.Log4net\AWS.Logger.Log4net.csproj", "{78312E9B-BC7C-4AF8-9153-DD72BBF4FD36}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.Log4net", "src\AWS.Logger.Log4net\AWS.Logger.Log4net.csproj", "{78312E9B-BC7C-4AF8-9153-DD72BBF4FD36}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.AWS.Logger", "src\NLog.AWS.Logger\NLog.AWS.Logger.csproj", "{5BBF70EA-A239-4A42-B1E6-83ADCC01153B}"
 EndProject
@@ -39,11 +39,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProgrammaticConfigurationEx
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.NLog.Tests", "test\AWS.Logger.NLog.Tests\AWS.Logger.NLog.Tests.csproj", "{F7986868-9D7E-4DF6-A57E-E79E38AD166D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWS.Logger.Log4Net.Tests", "test\AWS.Logger.Log4Net.Tests\AWS.Logger.Log4Net.Tests.csproj", "{C63B828F-D01D-4CA3-922D-5E283DD1CCF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.Log4Net.Tests", "test\AWS.Logger.Log4Net.Tests\AWS.Logger.Log4Net.Tests.csproj", "{C63B828F-D01D-4CA3-922D-5E283DD1CCF1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.NLog.FilterTests", "test\AWS.Logger.NLog.FilterTests\AWS.Logger.NLog.FilterTests.csproj", "{48377844-B524-46AC-B465-246A1552FE64}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AWS.Logger.Log4Net.FilterTests", "test\AWS.Logger.Log4Net.FilterTests\AWS.Logger.Log4Net.FilterTests.csproj", "{1A4E2BC7-CFE5-4532-9CFD-4DC1EFA0AD82}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.Log4Net.FilterTests", "test\AWS.Logger.Log4Net.FilterTests\AWS.Logger.Log4Net.FilterTests.csproj", "{1A4E2BC7-CFE5-4532-9CFD-4DC1EFA0AD82}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.TestUtils", "test\AWS.Logger.TestUtils\AWS.Logger.TestUtils.csproj", "{ADFF6031-0F8E-4EED-8E28-F29F0900BC11}"
 EndProject
@@ -58,6 +58,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.SeriLog.Tests", "test\AWS.Logger.SeriLog.Tests\AWS.Logger.SeriLog.Tests.csproj", "{D18AD3E0-9465-4393-AEDB-F2E75DEE839C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Logger.SeriLog", "src\AWS.Logger.SeriLog\AWS.Logger.SeriLog.csproj", "{916D3A6A-3713-48FB-8978-1440CD02F782}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicAWSCredentialsConfigurationExample", "samples\Log4net\BasicAWSCredentialsConfigurationExample\BasicAWSCredentialsConfigurationExample.csproj", "{7249C7F3-A0EF-4940-9931-3096C87E009E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -141,6 +143,10 @@ Global
 		{916D3A6A-3713-48FB-8978-1440CD02F782}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{916D3A6A-3713-48FB-8978-1440CD02F782}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{916D3A6A-3713-48FB-8978-1440CD02F782}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7249C7F3-A0EF-4940-9931-3096C87E009E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7249C7F3-A0EF-4940-9931-3096C87E009E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7249C7F3-A0EF-4940-9931-3096C87E009E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7249C7F3-A0EF-4940-9931-3096C87E009E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -168,6 +174,7 @@ Global
 		{14E1469E-4799-486D-ABD9-873283BF31EE} = {5646565D-E0F8-4EB3-AE6A-6C288B831C7A}
 		{D18AD3E0-9465-4393-AEDB-F2E75DEE839C} = {5646565D-E0F8-4EB3-AE6A-6C288B831C7A}
 		{916D3A6A-3713-48FB-8978-1440CD02F782} = {E3018A04-6209-4500-B8F2-706514407F90}
+		{7249C7F3-A0EF-4940-9931-3096C87E009E} = {D28DFB15-FA6F-42EE-890C-E6300A187CCA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46F50BDA-08A5-4A81-9CA9-F0B732C341A7}

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/App.config
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7249C7F3-A0EF-4940-9931-3096C87E009E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>BasicAWSCredentialsConfigurationExample</RootNamespace>
+    <AssemblyName>BasicAWSCredentialsConfigurationExample</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="README.md" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
@@ -31,6 +31,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\AWSSDK.Core.3.3.27\lib\net45\AWSSDK.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -46,7 +52,22 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="log4net.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
     <None Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\AWS.Logger.Core\AWS.Logger.Core.csproj">
+      <Project>{1d79e360-24d9-46fd-b744-63eabb17a1f6}</Project>
+      <Name>AWS.Logger.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\AWS.Logger.Log4net\AWS.Logger.Log4net.csproj">
+      <Project>{78312e9b-bc7c-4af8-9153-dd72bbf4fd36}</Project>
+      <Name>AWS.Logger.Log4net</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/Program.cs
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BasicAWSCredentialsConfigurationExample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+
+        }
+    }
+}

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/Program.cs
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/Program.cs
@@ -1,16 +1,80 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Amazon.Runtime;
+using AWS.Logger.Log4net;
+using log4net;
+using log4net.Layout;
+using log4net.Repository.Hierarchy;
+using System;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BasicAWSCredentialsConfigurationExample
 {
     public class Program
     {
+        private static readonly ILog log = LogManager.GetLogger(nameof(Program));
+
+        private const string logLayoutPattern = "%utcdate{yyyy-MM-ddTHH:mm:ss.fffZ} [%-5level] %logger - %message%newline";
+        private const string logGroup = "Log4net.BasicAWSCredentialsConfigurationExample";
+        private const string awsRegion = "ap-southeast-1";
+
         public static void Main(string[] args)
         {
+            var credentials = CreateCredentials(args);
+            var appender = CreateAppender(credentials);
 
+            //Get a reference to an existing logger name "Program" in log4net.config
+            var hierarchy = (Hierarchy)log.Logger.Repository;
+            var logger = hierarchy.GetLogger(nameof(Program)) as Logger;
+
+            //Attach the CloudWatch Logs appender
+            logger.AddAppender(appender);
+
+            //Start writing log to CloudWatch Logs
+            log.Info($"Check the AWS Console CloudWatch Logs console in {awsRegion} region");
+            log.Info("to see messages in the log streams for the");
+            log.Info($"log group {logGroup}");
+        }
+
+        private static BasicAWSCredentials CreateCredentials(string[] args)
+        {
+            if (args == null || !args.Any())
+            {
+                throw new ArgumentNullException(
+                    "args",
+                    "Please pass AWS API key and secret key as command line arguments"
+                );
+            }
+
+            //Warning!!! This is only a simple example, not for a production code.
+            var awsApiKey = args[0];
+            var awsSecretKey = args[1];
+
+            //Output values to verify that we have pass a values from command line arguments
+            Console.WriteLine(
+                $"{nameof(awsApiKey)}: {awsApiKey.Substring(0, 8)}, " +
+                $"{nameof(awsSecretKey)}: {awsSecretKey.Substring(0, 8)}"
+            );
+
+            return new BasicAWSCredentials(awsApiKey, awsSecretKey);
+        }
+
+        private static AWSAppender CreateAppender(AWSCredentials credentials)
+        {
+            var patternLayout = new PatternLayout
+            {
+                ConversionPattern = logLayoutPattern
+            };
+            patternLayout.ActivateOptions();
+
+            var appender = new AWSAppender
+            {
+                Layout = patternLayout,
+                Credentials =credentials,
+                LogGroup = logGroup,
+                Region = awsRegion
+            };
+
+            appender.ActivateOptions();
+            return appender;
         }
     }
 }

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/Properties/AssemblyInfo.cs
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/Properties/AssemblyInfo.cs
@@ -33,3 +33,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config", Watch = true)]

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/Properties/AssemblyInfo.cs
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BasicAWSCredentialsConfigurationExample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BasicAWSCredentialsConfigurationExample")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7249c7f3-a0ef-4940-9931-3096c87e009e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/README.md
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/README.md
@@ -1,5 +1,5 @@
 ﻿#Introduction
-This project shows you how to configure AWS CloudWatchLog with AWS basic credentials.
+This project shows you how to configure AWS CloudWatch Logs with basic AWS credentials.
 
 It is useful for a project that is not hosted on an AWS environment, e.g. 
 other dedicated servers, on-premise server.
@@ -12,5 +12,5 @@ other dedicated servers, on-premise server.
 - Select the Debug tab and then add your AWS API key and secret key to Command line arguments text box as 
   the following pattern: `YouAwsApiKey YourAwsSecretKey`
 - Run a project with debugging by pressing `F5`
-- Log in to your AWS console, go to Cloud watch log. You should see a new log message in
+- Log in to your AWS console, go to CloudWatch Logs. You should see a new log message in
 `Log4net.BasicAWSCredentialsConfigurationExample` group.

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/README.md
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/README.md
@@ -1,0 +1,16 @@
+﻿#Introduction
+This project shows you how to configure AWS CloudWatchLog with AWS basic credentials.
+
+It is useful for a project that is not hosted on an AWS environment, e.g. 
+other dedicated servers, on-premise server.
+
+#How to run a project
+- Open a project with Visual Studio
+- In the Solution Explorer window, right click on the project name node. 
+  Select `Set as Startup Project`
+- Go to the project properties window
+- Select the Debug tab and then add your AWS API key and secret key to Command line arguments text box as 
+  the following pattern: `YouAwsApiKey YourAwsSecretKey`
+- Run a project with debugging by pressing `F5`
+- Log in to your AWS console, go to Cloud watch log. You should see a new log message in
+`Log4net.BasicAWSCredentialsConfigurationExample` group.

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/log4net.config
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/log4net.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender" >
+        <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%utcdate{yyyy-MM-ddTHH:mm:ss.fffZ} [%-5level] %logger - %message%newline" />
+        </layout>
+    </appender>
+    <logger name="Program">
+        <!--Log message from INFO level only-->
+        <level value="INFO" />
+        <appender-ref ref="ConsoleAppender" />
+    </logger>
+    <root>
+    </root>
+</log4net>

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/packages.config
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AWSSDK.Core" version="3.3.27" targetFramework="net45" />
+  <package id="log4net" version="2.0.5" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Example project of using log4net and basic AWS credentials

This project shows you how to configure AWS CloudWatch Logs with basic AWS credentials.
It is useful for a project that is not hosted on an AWS environment, e.g. 
other dedicated servers, on-premise server


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
