### PR TITLE
User-defined log stream prefix (issue #83)

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Extensions.Configuration
         internal const string LOG_LEVEL = "LogLevel";
         internal const string MAX_QUEUED_MESSAGES = "MaxQueuedMessages";
         internal const string LOG_STREAM_NAME_SUFFIX = "LogStreamNameSuffix";
+        internal const string LOG_STREAM_NAME_PREFIX = "LogStreamNamePrefix";
         internal const string LIBRARY_LOG_FILE_NAME = "LibraryLogFileName";
         internal const string INCLUDE_SCOPES_NAME = "IncludeScopes";
 
@@ -95,6 +96,10 @@ namespace Microsoft.Extensions.Configuration
             if (loggerConfigSection[LOG_STREAM_NAME_SUFFIX] != null)
             {
                 Config.LogStreamNameSuffix = loggerConfigSection[LOG_STREAM_NAME_SUFFIX];
+            }
+            if (loggerConfigSection[LOG_STREAM_NAME_PREFIX] != null)
+            {
+                Config.LogStreamNamePrefix = loggerConfigSection[LOG_STREAM_NAME_PREFIX];
             }
             if (loggerConfigSection[LIBRARY_LOG_FILE_NAME] != null)
             {

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -129,12 +129,22 @@ namespace AWS.Logger
         /// <summary>
         /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of a DateTimeStamp as the prefix and a user defined suffix value that can 
         /// be set using the LogStreamNameSuffix property defined here.
-        /// The LogstreamName then follows the pattern '[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogstreamNameSuffix]'
+        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'
         /// <para>
         /// The default is going to a Guid.
         /// </para>
         /// </summary>
         public string LogStreamNameSuffix { get; set; } = Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix (that can be set here)
+        /// followed by a DateTimeStamp as the prefix, and a user defined suffix value
+        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'
+        /// <para>
+        /// The default is an empty string.
+        /// </para>
+        /// </summary>
+        public string LogStreamNamePrefix { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -444,7 +444,7 @@ namespace AWS.Logger.Core
                 }
             }
 
-            var currentStreamName = DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss") + " - " + _config.LogStreamNameSuffix;
+            var currentStreamName = GenerateStreamName();
 
             var streamResponse = await _client.CreateLogStreamAsync(new CreateLogStreamRequest
             {
@@ -459,6 +459,22 @@ namespace AWS.Logger.Core
             _repo = new LogEventBatch(_config.LogGroup, currentStreamName, Convert.ToInt32(_config.BatchPushInterval.TotalSeconds), _config.BatchSizeInBytes);
 
             return currentStreamName;
+        }
+
+        /// <summary>
+        /// generate a logstream name
+        /// </summary>
+        /// <returns>logstream name that ALWAYS includes a unique date-based segment</returns>
+        private string GenerateStreamName()
+        {
+            var suffix = _config.LogStreamNameSuffix;
+            var prefix = _config.LogStreamNamePrefix ?? string.Empty;
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                prefix += " - ";  //if there WAS a user-specified prefix, let's use it, followed by a separator
+            }
+
+            return prefix + DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss") + " - " + suffix;
         }
 
         private static bool IsSuccessStatusCode(AmazonWebServiceResponse serviceResponse)

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -128,8 +128,8 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
-        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of a DateTimeStamp as the prefix and a user defined suffix value that can 
-        /// be set using the LogStreamNameSuffix property defined here.
+        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined prefix segment, then a DateTimeStamp as the
+        /// system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property defined here.
         /// <para>
         /// The default is going to a Guid.
         /// </para>
@@ -138,6 +138,19 @@ namespace AWS.Logger.Log4net
         {
             get { return _config.LogStreamNameSuffix; }
             set { _config.LogStreamNameSuffix = value; }
+        }
+
+        /// <summary>
+        /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined prefix segment (defined here), then a
+        /// DateTimeStamp as the system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property.
+        /// <para>
+        /// The default will use an empty string for this user-defined portion, meaning the log stream name will start with the system-defined portion of the prefix (yyyy/MM/dd ... )
+        /// </para>
+        /// </summary>
+        public string LogStreamNamePrefix
+        {
+            get { return _config.LogStreamNamePrefix; }
+            set { _config.LogStreamNamePrefix = value; }
         }
 
         /// <summary>
@@ -173,6 +186,7 @@ namespace AWS.Logger.Log4net
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
 				LogStreamNameSuffix = LogStreamNameSuffix,
+                LogStreamNamePrefix = LogStreamNamePrefix,
 				LibraryLogFileName = LibraryLogFileName
             };
             _core = new AWSLoggerCore(config, "Log4net");

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -18,6 +18,7 @@ namespace AWS.Logger.SeriLog
         internal const string BATCH_PUSH_SIZE_IN_BYTES = "Serilog:BatchPushSizeInBytes";
         internal const string MAX_QUEUED_MESSAGES = "Serilog:MaxQueuedMessages";
         internal const string LOG_STREAM_NAME_SUFFIX = "Serilog:LogStreamNameSuffix";
+        internal const string LOG_STREAM_NAME_PREFIX = "Serilog:LogStreamNamePrefix";
         internal const string LIBRARY_LOG_FILE_NAME = "Serilog:LibraryLogFileName";
 
         /// <summary>
@@ -57,6 +58,10 @@ namespace AWS.Logger.SeriLog
             if (configuration[LOG_STREAM_NAME_SUFFIX] != null)
             {
                 config.LogStreamNameSuffix = configuration[LOG_STREAM_NAME_SUFFIX];
+            }
+            if (configuration[LOG_STREAM_NAME_PREFIX] != null)
+            {
+                config.LogStreamNamePrefix = configuration[LOG_STREAM_NAME_PREFIX];
             }
             if (configuration[LIBRARY_LOG_FILE_NAME] != null)
             {

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -132,8 +132,8 @@ namespace NLog.AWS.Logger
         }
 
         /// <summary>
-        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of a DateTimeStamp as the prefix and a user defined suffix value that can 
-        /// be set using the LogStreamNameSuffix property defined here.
+        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined prefix segment, then a DateTimeStamp as the
+        /// system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property defined here.
         /// <para>
         /// The default is going to a Guid.
         /// </para>
@@ -142,6 +142,19 @@ namespace NLog.AWS.Logger
         {
             get { return _config.LogStreamNameSuffix; }
             set { _config.LogStreamNameSuffix = value; }
+        }
+
+        /// <summary>
+        /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined prefix segment (defined here), then a
+        /// DateTimeStamp as the system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property.
+        /// <para>
+        /// The default will use an empty string for this user-defined portion, meaning the log stream name will start with the system-defined portion of the prefix (yyyy/MM/dd ... )
+        /// </para>
+        /// </summary>
+        public string LogStreamNamePrefix
+        {
+            get { return _config.LogStreamNamePrefix; }
+            set { _config.LogStreamNamePrefix = value; }
         }
 
         /// <summary>
@@ -175,6 +188,7 @@ namespace NLog.AWS.Logger
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
                 LogStreamNameSuffix = RenderSimpleLayout(LogStreamNameSuffix, nameof(LogStreamNameSuffix)),
+                LogStreamNamePrefix = RenderSimpleLayout(LogStreamNamePrefix, nameof(LogStreamNamePrefix)),
                 LibraryLogFileName = LibraryLogFileName
             };
             _core = new AWSLoggerCore(config, "NLog");

--- a/test/AWS.Logger.AspNetCore.Tests/appsettings.json
+++ b/test/AWS.Logger.AspNetCore.Tests/appsettings.json
@@ -3,6 +3,7 @@
     "LogGroup": "AWSILogger",
     "Region": "us-west-2",
     "LogStreamNameSuffix": "Custom",
+    "LogStreamNamePrefix": "CustomPrefix",
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",

--- a/test/AWS.Logger.Log4Net.Tests/log4net.config
+++ b/test/AWS.Logger.Log4Net.Tests/log4net.config
@@ -7,16 +7,17 @@
     <LogGroup>AWSLog4NetGroupLog4Net</LogGroup>
     <Region>us-west-2</Region>
     <LogStreamNameSuffix>Custom</LogStreamNameSuffix>
-      <layout type="log4net.Layout.PatternLayout">
+    <LogStreamNamePrefix>CustomPrefix</LogStreamNamePrefix>
+    <layout type="log4net.Layout.PatternLayout">
       <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message%newline" />
     </layout>
   </appender>
 
   <!-- Set root logger level to DEBUG and its only appender to A1 -->
-  
+
   <root>
     <level value ="DEBUG"/>
     <appender-ref ref="AWS" />
   </root>
-  
+
 </log4net>

--- a/test/AWS.Logger.NLog.Tests/Regular.config
+++ b/test/AWS.Logger.NLog.Tests/Regular.config
@@ -5,7 +5,7 @@
     <add assembly ="NLog.AWS.Logger"/>
   </extensions>
   <targets>
-    <target name="AWSNLogGroup" type="AWSTarget" logGroup="AWSNLogGroup" region="us-west-2" logStreamNameSuffix="Custom"/>
+    <target name="AWSNLogGroup" type="AWSTarget" logGroup="AWSNLogGroup" region="us-west-2" logStreamNameSuffix="Custom" logStreamNamePrefix="CustomPrefix"/>
     <target name="loggerRegular" xsi:type="Console" layout="${callsite} ${message}" />
   </targets>
   <rules>

--- a/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroup.json
+++ b/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroup.json
@@ -5,6 +5,7 @@
     "LogGroup": "AWSSeriLogGroup",
     "Region": "us-west-2",
     "LogStreamNameSuffix": "Custom",
+    "LogStreamNamePrefix": "CustomPrefix",
     "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
   }
 }

--- a/test/AWS.Logger.TestUtils/BaseTestClass.cs
+++ b/test/AWS.Logger.TestUtils/BaseTestClass.cs
@@ -19,6 +19,7 @@ namespace AWS.Logger.TestUtils
         public const int THREAD_COUNT = 2;
         public const string LASTMESSAGE = "LASTMESSAGE";
         public const string CUSTOMSTREAMSUFFIX = "Custom";
+        public const string CUSTOMSTREAMPREFIX = "CustomPrefix";
         public TestFixture _testFixture;
         public AmazonCloudWatchLogsClient Client;
 
@@ -105,12 +106,15 @@ namespace AWS.Logger.TestUtils
 
                 var customStreamSuffix = describeLogstreamsResponse.LogStreams[0].LogStreamName.Split('-').Last().Trim();
                 Assert.Equal(CUSTOMSTREAMSUFFIX, customStreamSuffix);
+                var customStreamPrefix = describeLogstreamsResponse.LogStreams[0].LogStreamName.Split('-').First().Trim();
+                Assert.Equal(CUSTOMSTREAMPREFIX, customStreamPrefix);
             }
             Assert.Equal(SIMPLELOGTEST_COUNT, getLogEventsResponse.Events.Count());
 
 
             _testFixture.LogGroupNameList.Add(logGroupName);
         }
+        
 
         protected void MultiThreadTestGroup(string logGroupName)
         {


### PR DESCRIPTION
Issue #83 

Added LogStreamPrefix to allow the library user, optionally, to specify a user-defined segment of the log stream prefix. If specified, the log stream name will begin with this user-defined segment, followed by the system-defined prefix segment of the yyyy/mm/dd form, then followed by the suffix (user defined or system defined, as in prior state).

Enhanced unit tests for all supported unit test frameworks to test LogStreamPrefix in a manner similar to the pre-existing LogStreamSuffix.

**The design invariant that a unique date-based component be included in the log stream name is maintained.** 

Backwards compatibility is maintained, as leaving the LogStreamPrefix null or empty results in behavior identical to the prior state.

As per design of the CloudWatch log stream enumeration API, this allows for significantly more efficient filtered enumeration of log streams within a log group, when the user wants to filter by a meaningful (rather than date-based) prefix. [see logStreamNamePrefix property](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html#CWL-DescribeLogStreams-request-logStreamNamePrefix)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
