### PR TITLE
Fixed issue with SendMessages timeout led to Monitor loop break

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -366,6 +366,12 @@ namespace AWS.Logger.Core
 
                     executeFlush = await _flushTriggerEvent.WaitAsync(TimeSpan.FromMilliseconds(_config.MonitorSleepTime.TotalMilliseconds), token);
                 }
+                catch (OperationCanceledException ex) when (!token.IsCancellationRequested)
+                {
+                    // Workaround to handle timeouts of .net httpclient 
+                    // https://github.com/dotnet/corefx/issues/20296
+                    LogLibraryServiceError(ex);
+                }
                 catch (OperationCanceledException ex)
                 {
                     if (!token.IsCancellationRequested || !_repo.IsEmpty || !_pendingMessageQueue.IsEmpty)


### PR DESCRIPTION
*Issues #73, #20*

Prevent `Monitor` loop to break on http timeout during logs sending. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
