### PR TITLE
add DontCreateLogGroup, to make auto-creation of Log Groups optional

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -115,6 +115,7 @@ namespace Microsoft.Extensions.Configuration
         public bool IncludeException { get; set; } = AWS.Logger.AspNetCore.Constants.IncludeExceptionDefault;
 
         internal const string LOG_GROUP = "LogGroup";
+        internal const string DONT_CREATE_LOG_GROUP = "DontCreateLogGroup";
         internal const string REGION = "Region";
         internal const string PROFILE = "Profile";
         internal const string PROFILE_LOCATION = "ProfilesLocation";
@@ -140,6 +141,7 @@ namespace Microsoft.Extensions.Configuration
         public AWSLoggerConfigSection(IConfiguration loggerConfigSection)
         {
             Config.LogGroup = loggerConfigSection[LOG_GROUP];
+            Config.DontCreateLogGroup = loggerConfigSection.GetValue<bool>(DONT_CREATE_LOG_GROUP);
             if (loggerConfigSection[REGION] != null)
             {
                 Config.Region = loggerConfigSection[REGION];

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -27,6 +27,15 @@ namespace AWS.Logger
         public string LogGroup { get; set; }
 
         /// <summary>
+        /// Determines whether or not to create a new Log Group, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// If false (the default), the Log Group is created if it doesn't already exist. This requires logs:DescribeLogGroups
+        /// permission to determine if the group exists, and logs:CreateLogGroup permission to create the group if it doesn't already exist.
+        /// If true, creation of Log Groups is disabled. Logging functions only if the specified log group already exists.
+        /// When creation of log groups is disabled, logs:DescribeLogGroups permission is NOT required.
+        /// </summary>
+        public bool DontCreateLogGroup { get; set; }
+
+        /// <summary>
         /// Gets and sets the Profile property. The profile is used to look up AWS credentials in the profile store.
         /// <para>
         /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -426,21 +426,25 @@ namespace AWS.Logger.Core
         private async Task<string> LogEventTransmissionSetup(CancellationToken token)
         {
             string serviceURL = GetServiceUrl();
-            var logGroupResponse = await _client.DescribeLogGroupsAsync(new DescribeLogGroupsRequest
-            {
-                LogGroupNamePrefix = _config.LogGroup
-            }, token).ConfigureAwait(false);
-            if (!IsSuccessStatusCode(logGroupResponse))
-            {
-                LogLibraryServiceError(new System.Net.WebException($"Lookup LogGroup {_config.LogGroup} returned status: {logGroupResponse.HttpStatusCode}"), serviceURL);
-            }
 
-            if (logGroupResponse.LogGroups.FirstOrDefault(x => string.Equals(x.LogGroupName, _config.LogGroup, StringComparison.Ordinal)) == null)
+            if (!_config.DontCreateLogGroup)
             {
-                var createGroupResponse = await _client.CreateLogGroupAsync(new CreateLogGroupRequest { LogGroupName = _config.LogGroup }, token).ConfigureAwait(false);
-                if (!IsSuccessStatusCode(createGroupResponse))
+                var logGroupResponse = await _client.DescribeLogGroupsAsync(new DescribeLogGroupsRequest
                 {
-                    LogLibraryServiceError(new System.Net.WebException($"Create LogGroup {_config.LogGroup} returned status: {createGroupResponse.HttpStatusCode}"), serviceURL);
+                    LogGroupNamePrefix = _config.LogGroup
+                }, token).ConfigureAwait(false);
+                if (!IsSuccessStatusCode(logGroupResponse))
+                {
+                    LogLibraryServiceError(new System.Net.WebException($"Lookup LogGroup {_config.LogGroup} returned status: {logGroupResponse.HttpStatusCode}"), serviceURL);
+                }
+
+                if (logGroupResponse.LogGroups.FirstOrDefault(x => string.Equals(x.LogGroupName, _config.LogGroup, StringComparison.Ordinal)) == null)
+                {
+                    var createGroupResponse = await _client.CreateLogGroupAsync(new CreateLogGroupRequest { LogGroupName = _config.LogGroup }, token).ConfigureAwait(false);
+                    if (!IsSuccessStatusCode(createGroupResponse))
+                    {
+                        LogLibraryServiceError(new System.Net.WebException($"Create LogGroup {_config.LogGroup} returned status: {createGroupResponse.HttpStatusCode}"), serviceURL);
+                    }
                 }
             }
 

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -15,6 +15,15 @@ namespace AWS.Logger
         string LogGroup { get; }
 
         /// <summary>
+        /// Determines whether or not to create a new Log Group, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// If false (the default), the Log Group is created if it doesn't already exist. This requires logs:DescribeLogGroups
+        /// permission to determine if the group exists, and logs:CreateLogGroup permission to create the group if it doesn't already exist.
+        /// If true, creation of Log Groups is disabled. Logging functions only if the specified log group already exists.
+        /// When creation of log groups is disabled, logs:DescribeLogGroups permission is NOT required.
+        /// </summary>
+        bool DontCreateLogGroup { get; set; }
+
+        /// <summary>
         /// Gets the Profile property. The profile is used to look up AWS credentials in the profile store.
         /// <para>
         /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -35,6 +35,16 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
+        /// Determines whether or not to create a new Log Group, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// <seealso cref="AWSLoggerConfig.DontCreateLogGroup"/>
+        /// </summary>
+        public bool DontCreateLogGroup
+        {
+            get { return _config.DontCreateLogGroup; }
+            set { _config.DontCreateLogGroup = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the Profile property. The profile is used to look up AWS credentials in the profile store.
         /// <para>
         /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
@@ -178,6 +188,7 @@ namespace AWS.Logger.Log4net
 
             var config = new AWSLoggerConfig(this.LogGroup)
             {
+                DontCreateLogGroup = DontCreateLogGroup,
                 Region = Region,
                 Credentials = Credentials,
                 Profile = Profile,

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -12,6 +12,7 @@ namespace AWS.Logger.SeriLog
     public static class AWSLoggerSeriLogExtension
     {
         internal const string LOG_GROUP = "Serilog:LogGroup";
+        internal const string DONT_CREATE_LOG_GROUP = "Serilog:DontCreateLogGroup";
         internal const string REGION = "Serilog:Region";
         internal const string PROFILE = "Serilog:Profile";
         internal const string PROFILE_LOCATION = "Serilog:ProfilesLocation";
@@ -36,6 +37,10 @@ namespace AWS.Logger.SeriLog
             AWSLoggerConfig config = new AWSLoggerConfig();
 
             config.LogGroup = configuration[LOG_GROUP];
+            if (configuration[DONT_CREATE_LOG_GROUP] != null)
+            {
+                config.DontCreateLogGroup = bool.Parse(configuration[DONT_CREATE_LOG_GROUP]);
+            }
             if (configuration[REGION] != null)
             {
                 config.Region = configuration[REGION];

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -40,6 +40,16 @@ namespace NLog.AWS.Logger
         }
 
         /// <summary>
+        /// Determines whether or not to create a new Log Group, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// <seealso cref="AWSLoggerConfig.DontCreateLogGroup"/>
+        /// </summary>
+        public bool DontCreateLogGroup
+        {
+            get { return _config.DontCreateLogGroup; }
+            set { _config.DontCreateLogGroup = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the Profile property. The profile is used to look up AWS credentials in the profile store.
         /// <para>
         /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.
@@ -180,6 +190,7 @@ namespace NLog.AWS.Logger
 
             var config = new AWSLoggerConfig(RenderSimpleLayout(LogGroup, nameof(LogGroup)))
             {
+                DontCreateLogGroup = DontCreateLogGroup,
                 Region = RenderSimpleLayout(Region, nameof(Region)),
                 Credentials = Credentials,
                 Profile = RenderSimpleLayout(Profile, nameof(Profile)),

--- a/test/AWS.Logger.AspNetCore.Tests/TestConfigurationBase.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestConfigurationBase.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace AWS.Logger.AspNetCore.Tests
+{
+    /// <summary>
+    /// provides access to methods helpful when dealing with configuration in .net core JSON form
+    /// </summary>
+    public class TestConfigurationBase
+    {
+        /// <summary>
+        /// read IConfiguration from a JSON file, for testing purposes
+        /// </summary>
+        /// <param name="jsonFileName"></param>
+        /// <param name="configSectionInfoBlockName"></param>
+        /// <param name="sourceFilePath"></param>
+        /// <returns>IConfiguration from a JSON file</returns>
+        public IConfiguration LoggerConfigSectionSetup(string jsonFileName, string configSectionInfoBlockName, [System.Runtime.CompilerServices.CallerFilePath]string sourceFilePath = "")
+        {
+            var configurationBuilder = new ConfigurationBuilder()
+                                       .SetBasePath(Path.GetDirectoryName(sourceFilePath))
+                                       .AddJsonFile(jsonFileName);
+
+            IConfiguration Config;
+            if (configSectionInfoBlockName != null)
+            {
+                Config = configurationBuilder
+                    .Build()
+                    .GetSection(configSectionInfoBlockName);
+            }
+
+            else
+            {
+                Config = configurationBuilder
+                      .Build()
+                      .GetSection("AWS.Logging");
+            }
+
+            return Config;
+
+        }
+    }
+}

--- a/test/AWS.Logger.AspNetCore.Tests/TestDontCreateLogGroup.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestDontCreateLogGroup.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Xunit;
+using AWS.Logger.AspNetCore;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Amazon.CloudWatchLogs;
+using Amazon.CloudWatchLogs.Model;
+using AWS.Logger.TestUtils;
+namespace AWS.Logger.AspNetCore.Tests
+{
+    public class TestDontCreateLogGroup : TestConfigurationBase
+    {
+        [Fact]
+        public void TestMissingDontCreateLogGroup()
+        {
+            var config = LoggerConfigSectionSetup("dontCreateLogGroupMissing.json", null);
+            var typed = new AWSLoggerConfigSection(config);
+            Assert.False(typed.Config.DontCreateLogGroup);
+        }
+
+        [Fact]
+        public void TestTrueDontCreateLogGroup()
+        {
+            var config = LoggerConfigSectionSetup("dontCreateLogGroupTrue.json", null);
+            var typed = new AWSLoggerConfigSection(config);
+            Assert.True(typed.Config.DontCreateLogGroup);
+        }
+    }
+}

--- a/test/AWS.Logger.AspNetCore.Tests/TestFilter.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestFilter.cs
@@ -12,34 +12,11 @@ namespace AWS.Logger.AspNetCore.Tests
 {
     // This project can output the Class library as a NuGet Package.
     // To enable this option, right-click on the project and select the Properties menu item. In the Build tab select "Produce outputs on build".
-    public class TestFilter
+    public class TestFilter : TestConfigurationBase
     {
         public AWSLoggerConfigSection ConfigSection;
 
-        public IConfiguration LoggerConfigSectionSetup(string jsonFileName,string configSectionInfoBlockName, [System.Runtime.CompilerServices.CallerFilePath]string sourceFilePath="")
-        {
-            var configurationBuilder = new ConfigurationBuilder()
-                                       .SetBasePath(Path.GetDirectoryName(sourceFilePath))
-                                       .AddJsonFile(jsonFileName);
 
-            IConfiguration Config;
-            if (configSectionInfoBlockName != null)
-            {
-                Config = configurationBuilder
-                    .Build()
-                    .GetSection(configSectionInfoBlockName);
-            }
-
-            else
-            {
-                Config = configurationBuilder
-                      .Build()
-                      .GetSection("AWS.Logging");
-            }
-
-            return Config;
-
-        }
         [Fact]
         public void FilterLogLevel()
         {

--- a/test/AWS.Logger.AspNetCore.Tests/dontCreateLogGroupMissing.json
+++ b/test/AWS.Logger.AspNetCore.Tests/dontCreateLogGroupMissing.json
@@ -1,0 +1,7 @@
+﻿{
+  "AWS.Logging": {
+    "LogGroup": "AWSILoggerGroup",
+    "Region": "us-west-2",
+    "LogStreamNameSuffix": "TestStream"
+  }
+}

--- a/test/AWS.Logger.AspNetCore.Tests/dontCreateLogGroupTrue.json
+++ b/test/AWS.Logger.AspNetCore.Tests/dontCreateLogGroupTrue.json
@@ -1,0 +1,8 @@
+﻿{
+  "AWS.Logging": {
+    "LogGroup": "AWSILoggerGroup",
+    "DontCreateLogGroup": true,
+    "Region": "us-west-2",
+    "LogStreamNameSuffix": "TestStream"
+  }
+}

--- a/test/AWS.Logger.UnitTests/DontCreateLogGroupTests.cs
+++ b/test/AWS.Logger.UnitTests/DontCreateLogGroupTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.CloudWatchLogs;
+using Amazon.CloudWatchLogs.Model;
+using AWS.Logger.Core;
+using AWS.Logger.TestUtils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AWS.Logger.UnitTests
+{
+    public class DontCreateLogGroupTests : IClassFixture<TestFixture>
+    {
+        /*AmazonCloudWatchLogsClient client; */
+
+
+        public DontCreateLogGroupTests(TestFixture testFixture, ITestOutputHelper output)
+        {
+            _testFixure = testFixture;
+            _output = output;
+        }
+
+        private readonly TestFixture _testFixure;
+        private readonly ITestOutputHelper _output;
+
+        [Fact]
+        public async Task TestCoreWithDontCreateLogGroup()
+        {
+            var logGroupName = nameof(TestCoreWithDontCreateLogGroup);
+
+            using (var client = new AmazonCloudWatchLogsClient(RegionEndpoint.USWest2))
+            {
+                var config = new AWSLoggerConfig(logGroupName ) 
+                {
+                    Region = RegionEndpoint.USWest2.SystemName,
+                    DontCreateLogGroup = true,
+                };
+
+                var resourceNotFoundPromise = new TaskCompletionSource<bool>();  // true means we saw expected exception; false otherwise
+                var core = new AWSLoggerCore(config, "unit");
+                core.LogLibraryAlert += (sender, e) =>
+                {
+                    if (e.Exception is ResourceNotFoundException)
+                    {
+                        // saw EXPECTED exception.
+                        resourceNotFoundPromise.TrySetResult(true);
+                    }
+                    else if (e.Exception != null)
+                    {
+                        _output.WriteLine("Was not expecting to see exception: {0} @{1}", e.Exception, e.ServiceUrl);
+                    }
+                };
+
+                var tsk = Task.Factory.StartNew(() =>
+                {    
+                    core.AddMessage("Test message added at " + DateTimeOffset.UtcNow.ToString());
+                    core.Flush();
+                });
+
+                await Task.WhenAny(tsk, resourceNotFoundPromise.Task).ConfigureAwait(false);
+                resourceNotFoundPromise.TrySetResult(false);
+                Assert.True(await resourceNotFoundPromise.Task);
+
+                // now we create the log group, late.
+                await client.CreateLogGroupAsync(new CreateLogGroupRequest
+                {
+                    LogGroupName = logGroupName
+                });
+                _testFixure.LogGroupNameList.Add(logGroupName);
+
+                // wait for the flusher task to finish, which should actually proceed OK, now that we've created the expected log group.
+                await tsk.ConfigureAwait(false);
+                core.Close();
+            }
+        }
+
+        [Fact]
+        public void TestCoreWithoutDontCreateLogGroup()
+        {
+            var logGroupName = nameof(TestCoreWithoutDontCreateLogGroup) + DateTime.UtcNow.Ticks; // this one will have to be auto-created.
+
+            using (var client = new AmazonCloudWatchLogsClient(RegionEndpoint.USWest2))
+            {
+                var config = new AWSLoggerConfig(logGroupName)
+                {
+                    Region = RegionEndpoint.USWest2.SystemName,
+                    DontCreateLogGroup = false,
+                };
+
+                var core = new AWSLoggerCore(config, "unit");
+                core.AddMessage("Test message added at " + DateTimeOffset.UtcNow.ToString());
+                core.Flush();
+                _testFixure.LogGroupNameList.Add(logGroupName); // let's enlist the auto-created group for deletion.
+                core.Close();
+            }
+        }
+
+    }
+}
+


### PR DESCRIPTION
Issue  #98

Added boolean "DontCreateLogGroup" property, to allow developers to switch off auto-creation of log groups. This avoids an API call to [DescribeLogGroups](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogGroups.html) (which is used to determine if the configured Log Group already exists), useful in scenarios where permission to enumerate log groups in the account is not available. 

Default behavior (DontCreateLogGroup == false) matches prior state behavior.

Added wireup for all supported logging frameworks.

Added tests (requiring some form of AWS access, as with many of the other tests), to help confirm, via AWSLoggerCore, that the new setting does indeed prevent auto-creation of log groups.

Added tests to verify that the configuration value is parsed properly (in an ASP.NET Core context, using IConfiguration), as this appears to be the first setting using GetValue<bool>.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
