### PR TITLE
Updated NLog config example to work on NetCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ is **NLog.config**. Here is an example config file that configures the AWS Regio
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      throwExceptions="true">
+	  throwConfigExceptions="true">
+  <extensions>
+    <add assembly="NLog.AWS.Logger" />
+  </extensions>
   <targets>
     <target name="aws" type="AWSTarget" logGroup="NLog.ConfigExample" region="us-east-1"/>
   </targets>

--- a/samples/NLog/ConfigExample/ConfigExample.csproj
+++ b/samples/NLog/ConfigExample/ConfigExample.csproj
@@ -34,8 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NLog.4.4.0\lib\net45\NLog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\NLog.4.5.0\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/samples/NLog/ConfigExample/NLog.config
+++ b/samples/NLog/ConfigExample/NLog.config
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      throwExceptions="true">
+      throwConfigExceptions="true">
+  <extensions>
+    <add assembly="NLog.AWS.Logger" />
+  </extensions>
   <targets>
     <target name="aws" type="AWSTarget" logGroup="NLog.ConfigExample" region="us-east-1"/>
     <target name="logfile" xsi:type="Console" layout="${callsite} ${message}" />

--- a/samples/NLog/ConfigExample/packages.config
+++ b/samples/NLog/ConfigExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.4.0" targetFramework="net46" />
+  <package id="NLog" version="4.5.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
@normj Fixed NLog-documentation so it will work on new NetCore-projects (autoloading of NLog-extension-assembly not working and needs help using `<extensions>`)

Also updated NLog-sample to have correct NLog-dependency-version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
