### PR TITLE
Updated library with new property to disable library error logging.

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Extensions.Configuration
         internal const string LOG_STREAM_NAME_SUFFIX = "LogStreamNameSuffix";
         internal const string LOG_STREAM_NAME_PREFIX = "LogStreamNamePrefix";
         internal const string LIBRARY_LOG_FILE_NAME = "LibraryLogFileName";
+        internal const string LIBRARY_LOG_ERRORS = "LibraryLogErrors";
 
         private const string INCLUDE_LOG_LEVEL_KEY = "IncludeLogLevel";
         private const string INCLUDE_CATEGORY_KEY = "IncludeCategory";
@@ -182,6 +183,10 @@ namespace Microsoft.Extensions.Configuration
             if (loggerConfigSection[LIBRARY_LOG_FILE_NAME] != null)
             {
                 Config.LibraryLogFileName = loggerConfigSection[LIBRARY_LOG_FILE_NAME];
+            }
+            if (loggerConfigSection[LIBRARY_LOG_ERRORS] != null)
+            {
+                Config.LibraryLogErrors = Boolean.Parse(loggerConfigSection[LIBRARY_LOG_ERRORS]);
             }
 
             if (loggerConfigSection[INCLUDE_LOG_LEVEL_KEY] != null)

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -161,7 +161,15 @@ namespace AWS.Logger
         public string LogStreamNamePrefix { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
+        /// Gets and sets the LibraryLogErrors property. This is the boolean value of whether or not you would like this library to log logging errors.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        public bool LibraryLogErrors { get; set; } = true;
+       
+        /// <summary>
+        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be written into.
         /// <para>
         /// The default is "aws-logger-errors.txt".
         /// </para>

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -646,7 +646,7 @@ namespace AWS.Logger.Core
         private void LogLibraryServiceError(Exception ex, string serviceUrl = null)
         {
             LogLibraryAlert?.Invoke(this, new LogLibraryEventArgs(ex) { ServiceUrl = serviceUrl ?? GetServiceUrl() } );
-            if (!string.IsNullOrEmpty(_config.LibraryLogFileName))
+            if (!string.IsNullOrEmpty(_config.LibraryLogFileName) && _config.LibraryLogErrors)
             {
                 LogLibraryError(ex, _config.LibraryLogFileName);
             }

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -109,6 +109,14 @@ namespace AWS.Logger
         string LogStreamNamePrefix { get; set; }
 
         /// <summary>
+        /// Gets and sets the LibraryLogErrors property. This is the boolean value of whether or not you would like this library to log logging errors.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        bool LibraryLogErrors { get; set; }
+        
+        /// <summary>
         /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
         /// <para>
         /// The default is going to "aws-logger-errors.txt".

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -175,6 +175,18 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
+        /// Gets and sets the LibraryLogErrors property. This is the boolean value of whether or not you would like this library to log logging errors.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        public bool LibraryLogErrors
+        {
+            get { return _config.LibraryLogErrors; }
+            set { _config.LibraryLogErrors = value; }
+        }
+        
+        /// <summary>
         /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
         /// <para>
         /// The default is going to "aws-logger-errors.txt".
@@ -210,6 +222,7 @@ namespace AWS.Logger.Log4net
                 MaxQueuedMessages = MaxQueuedMessages,
 				LogStreamNameSuffix = LogStreamNameSuffix,
                 LogStreamNamePrefix = LogStreamNamePrefix,
+                LibraryLogErrors = LibraryLogErrors,
 				LibraryLogFileName = LibraryLogFileName
             };
             _core = new AWSLoggerCore(config, "Log4net");

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -23,6 +23,7 @@ namespace AWS.Logger.SeriLog
         internal const string LOG_STREAM_NAME_SUFFIX = "Serilog:LogStreamNameSuffix";
         internal const string LOG_STREAM_NAME_PREFIX = "Serilog:LogStreamNamePrefix";
         internal const string LIBRARY_LOG_FILE_NAME = "Serilog:LibraryLogFileName";
+        internal const string LIBRARY_LOG_ERRORS = "Serilog:LibraryLogErrors";
 
         /// <summary>
         /// AWSSeriLogger target that is called when the customer is using 
@@ -81,6 +82,10 @@ namespace AWS.Logger.SeriLog
             if (configuration[LIBRARY_LOG_FILE_NAME] != null)
             {
                 config.LibraryLogFileName = configuration[LIBRARY_LOG_FILE_NAME];
+            }
+            if (configuration[LIBRARY_LOG_ERRORS] != null)
+            {
+                config.LibraryLogErrors = Boolean.Parse(configuration[LIBRARY_LOG_ERRORS]);
             }
             return AWSSeriLog(loggerConfiguration, config, iFormatProvider, textFormatter);
         }

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -177,6 +177,18 @@ namespace NLog.AWS.Logger
         }
 
         /// <summary>
+        /// Gets and sets the LibraryLogErrors property. This is the boolean value of whether or not you would like this library to log logging errors.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        public bool LibraryLogErrors
+        {
+            get { return _config.LibraryLogErrors; }
+            set { _config.LibraryLogErrors = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
         /// <para>
         /// The default is "aws-logger-errors.txt".
@@ -210,6 +222,7 @@ namespace NLog.AWS.Logger
                 MaxQueuedMessages = MaxQueuedMessages,
                 LogStreamNameSuffix = RenderSimpleLayout(LogStreamNameSuffix, nameof(LogStreamNameSuffix)),
                 LogStreamNamePrefix = RenderSimpleLayout(LogStreamNamePrefix, nameof(LogStreamNamePrefix)),
+                LibraryLogErrors = LibraryLogErrors,
                 LibraryLogFileName = LibraryLogFileName
             };
             _core = new AWSLoggerCore(config, "NLog");


### PR DESCRIPTION
Issue #118 

This PR adds a new property to disable the Library Log errors (instead of using an empty string)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
