### PR TITLE
Update version of the AWS SDK for .NET to the latest 3.5 version

### DIFF
--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AWSSDK.Core.3.3.27\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\AWSSDK.Core.3.5.1.22\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>

--- a/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
+++ b/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
@@ -21,7 +21,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>2.2.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -23,7 +23,7 @@
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>1.6.0</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.3.100.39" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.24" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
+++ b/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
@@ -22,7 +22,7 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>1.5.2</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.SeriLog/AWS.Logger.SeriLog.csproj
+++ b/src/AWS.Logger.SeriLog/AWS.Logger.SeriLog.csproj
@@ -22,7 +22,7 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>1.5.2</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
+++ b/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
@@ -23,7 +23,7 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>1.5.2</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
+++ b/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
+++ b/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
+++ b/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.5.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
+++ b/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.3.100.39" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
  
 </Project>

--- a/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
+++ b/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.101.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-logging-dotnet/issues/136

*Description of changes:*
Update references to the AWS SDK for .NET to the latest 3.5 version. Since this is a significant version bump I major version bumped all of the packages. Compatible is very high between 3.3. and 3.5 but just to make it obvious that SDK version changed to 3.5 it seemed worth bumping the major version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
