### PR TITLE
Changes to update log4net dependency to version 2.0.10

### DIFF
--- a/RELEASE.CHANGELOG.md
+++ b/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release 2021-01-29
+* **AWS.Logger.Log4net (3.0.0)**
+  * Updated to version 2.0.10 of the log4net. Version 2.0.10 contains a security fix for [CVE-2018-1285](https://github.com/advisories/GHSA-2cwj-8chv-9pp9)
+  * Removed support for .NET Standard 1.5.
+
 ### Release 2020-12-09
 * **AWS.Logger.Core (2.0.1)**
   * Merge PR [#134](https://github.com/aws/aws-logging-dotnet/pull/135) Handle ResourceNotFoundException whe CloudWatch Log stream is deleted. Thanks [Rolf Kristensen](https://github.com/snakefoot).

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
@@ -34,11 +34,13 @@
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\AWSSDK.Core.3.5.1.22\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/samples/Log4net/ConfigExample/ConfigExample.csproj
+++ b/samples/Log4net/ConfigExample/ConfigExample.csproj
@@ -32,11 +32,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/samples/Log4net/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
+++ b/samples/Log4net/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
@@ -32,11 +32,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/samples/Log4net/ProgrammaticConfigurationExample/packages.config
+++ b/samples/Log4net/ProgrammaticConfigurationExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.8" targetFramework="net45" />
+  <package id="log4net" version="2.0.10" targetFramework="net45" />
 </packages>

--- a/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
+++ b/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     
     <Description>An AWS Log4net appender that records logging messages to Amazon CloudWatch Logs.</Description>
     <Authors>Amazon Web Services</Authors>
@@ -19,10 +19,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>2.0.1</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the samples and change log for use version 2.0.10 of log4net. Looks like the assembly version number didn't change for package version 2.0.10 which is why you can see in the old style csproj show 2.0.9 in the assembly version but it is pulling in version 2.0.10.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
