### PR TITLE
Update AWS SDK dependencies to 3.7, and finish dropping .NET Standard 1.5 Support

### DIFF
--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\AWSSDK.Core.3.5.1.22\lib\net45\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\AWSSDK.Core.3.7.0.6\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.9.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\log4net.2.0.10\lib\net45\log4net.dll</HintPath>

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/packages.config
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.3.27" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.7.0.6" targetFramework="net45" />
   <package id="log4net" version="2.0.10" targetFramework="net45" />
 </packages>

--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
 
     <Description>AWS Core logging library used to send logging messages to Amazon CloudWatch Logs</Description>
     <Authors>Amazon Web Services</Authors>
@@ -19,11 +19,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
@@ -36,11 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.24" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/AWS.Logger.SeriLog/AWS.Logger.SeriLog.csproj
+++ b/src/AWS.Logger.SeriLog/AWS.Logger.SeriLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
     
     <Description>An AWS SeriLog sink that records logging messages to Amazon CloudWatch Logs.</Description>
     <Authors>Amazon Web Services</Authors>
@@ -19,10 +19,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
+++ b/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
 
     <PackageId>AWS.Logger.NLog</PackageId>
     <Description>An AWS NLog target that records logging messages to Amazon CloudWatch Logs.</Description>
@@ -20,10 +20,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
+++ b/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
+++ b/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
+++ b/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.5.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
+++ b/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.5.0.24" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
  
 </Project>

--- a/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
+++ b/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.4" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:* #160

*Description of changes:*
1. Updates AWS SDK dependencies to v3.7
2. Drops support for .NET Standard 1.5 where we did so, since [AWS SDK no longer supports .NET Standard 1.3](https://aws.amazon.com/blogs/developer/net-standard-1-3-is-no-longer-supported-in-aws-sdk-for-net-version-3-7/). Performed a major version bump.
    * Note we had previously done this for AWS.Logger.Log4net in #154 with that security fix


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
