### PR TITLE
Updated README with IAM permissions required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ may not ever be unfrozen if more Lambda events are not received for some time.
 When using Lambda it is recommended to use either the `ILambdaContext.Logger.LogLine` or the 
 [Amazon.Lambda.Logging.AspNetCore](https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/src/Amazon.Lambda.Logging.AspNetCore) package.
 
+### Required IAM Permissions
+
+Regardless of the framework used, the following permissions must be allowed (via [IAM](https://aws.amazon.com/iam)) for the provided AWS credentials.
+
+```
+logs:CreateLogGroup
+logs:CreateLogStream
+logs:PutLogEvents
+logs:DescribeLogGroups
+```
+
+The practice of granting least privilege access is recommended when setting up credentials. You can further reduce access by limiting permission scope to specific resources (such as a Log Stream) by referencing its ARN during policy creation.
+
+For more information and a sample JSON policy template, please see [Amazon CloudWatch Logs and .NET Logging Frameworks](https://aws.amazon.com/blogs/developer/amazon-cloudwatch-logs-and-net-logging-frameworks/) on the AWS Developer Blog.
+
 
 ## Supported Logging Frameworks
 


### PR DESCRIPTION
New section in the README provides a list of permissions required in IAM in order for the logging to function.

No issue associated.

Description:
Hi, this change simply adds a section to the README file providing a bit of extra guidance on the permissions required for the provided AWS credentials to save the next person from having to hunt down the answer. I found the answer on the AWS blog, and have referenced it in my update.


I confirm that my contribution is made under the terms of the Apache 2.0 license.
