### PR TITLE
Omit timestamp from logstream name (issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ logs:CreateLogGroup
 logs:CreateLogStream
 logs:PutLogEvents
 logs:DescribeLogGroups
+logs:DescribeLogStreams
 ```
 
 The practice of granting least privilege access is recommended when setting up credentials. You can further reduce access by limiting permission scope to specific resources (such as a Log Stream) by referencing its ARN during policy creation.

--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Extensions.Configuration
         internal const string MAX_QUEUED_MESSAGES = "MaxQueuedMessages";
         internal const string LOG_STREAM_NAME_SUFFIX = "LogStreamNameSuffix";
         internal const string LOG_STREAM_NAME_PREFIX = "LogStreamNamePrefix";
+        internal const string INCLUDE_TIMESTAMP_IN_LOG_STREAM_NAME = "IncludeTimestampInLogStreamName";
         internal const string LIBRARY_LOG_FILE_NAME = "LibraryLogFileName";
         internal const string LIBRARY_LOG_ERRORS = "LibraryLogErrors";
 
@@ -179,6 +180,10 @@ namespace Microsoft.Extensions.Configuration
             if (loggerConfigSection[LOG_STREAM_NAME_PREFIX] != null)
             {
                 Config.LogStreamNamePrefix = loggerConfigSection[LOG_STREAM_NAME_PREFIX];
+            }
+            if (loggerConfigSection[INCLUDE_TIMESTAMP_IN_LOG_STREAM_NAME] != null)
+            {
+                Config.IncludeTimestampInLogStreamName = Boolean.Parse(loggerConfigSection[INCLUDE_TIMESTAMP_IN_LOG_STREAM_NAME]);
             }
             if (loggerConfigSection[LIBRARY_LOG_FILE_NAME] != null)
             {

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -141,9 +141,18 @@ namespace AWS.Logger
         }
 
         /// <summary>
-        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix (that can be set here)
-        /// followed by a DateTimeStamp as the prefix, and a user defined suffix value
-        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'
+        /// Gets and sets the IncludeTimestampInLogStreamName property. Set to "true" if you wish to include a timestamp (formatted as "yyyy/MM/ddTHH.mm.ss")
+        /// as the core of the LogStreamName, set to "false" to omit the timestamp.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        public bool IncludeTimestampInLogStreamName { get; set; } = true;
+
+        /// <summary>
+        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix
+        /// followed by a timestamp if IncludeTimestampInLogStreamName is "true", and a user defined suffix value.
+        /// The LogStreamName then follows the pattern '[LogStreamNamePrefix] - [DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")] - [LogStreamNameSuffix]'.
         /// <para>
         /// The default is new a Guid.
         /// </para>
@@ -152,8 +161,8 @@ namespace AWS.Logger
 
         /// <summary>
         /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix (that can be set here)
-        /// followed by a DateTimeStamp as the prefix, and a user defined suffix value
-        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'
+        /// followed by a timestamp if IncludeTimestampInLogStreamName is "true", and a user defined suffix value
+        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix] - [DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")] - [LogStreamNameSuffix]'
         /// <para>
         /// The default is an empty string.
         /// </para>

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -493,29 +493,19 @@ namespace AWS.Logger.Core
         /// <summary>
         /// Generate a logstream name
         /// </summary>
-        /// <returns>logstream name that ALWAYS includes a unique date-based segment</returns>
+        /// <returns>A logstream name with a format based on the configuration passed to the method.</returns>
         public static string GenerateStreamName(IAWSLoggerConfig config)
         {
-            var streamName = new StringBuilder();
+            List<string> nameParts = new List<string>();
 
-            var prefix = config.LogStreamNamePrefix;
-            if (!string.IsNullOrEmpty(prefix))
-            {
-                streamName.Append(prefix);
-                streamName.Append(" - ");
-            }
+            if (!string.IsNullOrEmpty(config.LogStreamNamePrefix))
+                nameParts.Add(config.LogStreamNamePrefix);
+            if (config.IncludeTimestampInLogStreamName)
+                nameParts.Add(DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss"));
+            if (!string.IsNullOrEmpty(config.LogStreamNameSuffix))
+                nameParts.Add(config.LogStreamNameSuffix);
 
-            streamName.Append(DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss"));
-
-            var suffix = config.LogStreamNameSuffix;
-            if (!string.IsNullOrEmpty(suffix))
-            {
-                streamName.Append(" - ");
-                streamName.Append(suffix);
-            }
-
-
-            return streamName.ToString();
+            return string.Join(" - ", nameParts);
         }
 
         private static bool IsSuccessStatusCode(AmazonWebServiceResponse serviceResponse)

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -89,19 +89,28 @@ namespace AWS.Logger
         int MaxQueuedMessages { get; }
 
         /// <summary>
-        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix (that can be set here)
-        /// followed by a DateTimeStamp as the prefix, and a user defined suffix value
-        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'
+        /// Gets and sets the IncludeTimestampInLogStreamName property. Set to "true" if you wish to include a timestamp (formatted as "yyyy/MM/ddTHH.mm.ss")
+        /// as the core of the LogStreamName, set to "false" to omit the timestamp.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        bool IncludeTimestampInLogStreamName { get; set; }
+
+        /// <summary>
+        /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix
+        /// followed by a timestamp if IncludeTimestampInLogStreamName is "true", and a user defined suffix value.
+        /// The LogStreamName then follows the pattern '[LogStreamNamePrefix] - [DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")] - [LogStreamNameSuffix]'.
         /// <para>
         /// The default is new a Guid.
         /// </para>
         /// </summary>
-        string LogStreamNameSuffix { get; }
+        string LogStreamNameSuffix { get; set; }
 
         /// <summary>
         /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix (that can be set here)
-        /// followed by a DateTimeStamp as the prefix, and a user defined suffix value
-        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'
+        /// followed by a timestamp if IncludeTimestampInLogStreamName is "true", and a user defined suffix value
+        /// The LogstreamName then follows the pattern '[LogStreamNamePrefix] - [DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")] - [LogStreamNameSuffix]'
         /// <para>
         /// The default is an empty string.
         /// </para>

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -233,6 +233,7 @@ namespace AWS.Logger.Log4net
                 BatchPushInterval = BatchPushInterval,
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
+                IncludeTimestampInLogStreamName = IncludeTimestampInLogStreamName,
 				LogStreamNameSuffix = LogStreamNameSuffix,
                 LogStreamNamePrefix = LogStreamNamePrefix,
                 LibraryLogErrors = LibraryLogErrors,

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -149,6 +149,19 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
+        /// Gets and sets the IncludeTimestampInLogStreamName property. Set to "true" if you wish to include a timestamp (formatted as "yyyy/MM/ddTHH.mm.ss")
+        /// as the core of the LogStreamName, set to "false" to omit the timestamp.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        public bool IncludeTimestampInLogStreamName
+        {
+            get { return _config.IncludeTimestampInLogStreamName; }
+            set { _config.IncludeTimestampInLogStreamName = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined prefix segment, then a DateTimeStamp as the
         /// system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property defined here.
         /// <para>

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -21,6 +21,7 @@ namespace AWS.Logger.SeriLog
         internal const string BATCH_PUSH_INTERVAL = "Serilog:BatchPushInterval";
         internal const string BATCH_PUSH_SIZE_IN_BYTES = "Serilog:BatchPushSizeInBytes";
         internal const string MAX_QUEUED_MESSAGES = "Serilog:MaxQueuedMessages";
+        internal const string INCLUDE_TIMESTAMP_IN_LOG_STREAM_NAME = "Serilog:IncludeTimestampInLogStreamName";
         internal const string LOG_STREAM_NAME_SUFFIX = "Serilog:LogStreamNameSuffix";
         internal const string LOG_STREAM_NAME_PREFIX = "Serilog:LogStreamNamePrefix";
         internal const string LIBRARY_LOG_FILE_NAME = "Serilog:LibraryLogFileName";
@@ -72,6 +73,10 @@ namespace AWS.Logger.SeriLog
             if (configuration[MAX_QUEUED_MESSAGES] != null)
             {
                 config.MaxQueuedMessages = Int32.Parse(configuration[MAX_QUEUED_MESSAGES]);
+            }
+            if (configuration[INCLUDE_TIMESTAMP_IN_LOG_STREAM_NAME] != null)
+            {
+                config.IncludeTimestampInLogStreamName = Boolean.Parse(configuration[INCLUDE_TIMESTAMP_IN_LOG_STREAM_NAME]);
             }
             if (configuration[LOG_STREAM_NAME_SUFFIX] != null)
             {

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -151,6 +151,19 @@ namespace NLog.AWS.Logger
         }
 
         /// <summary>
+        /// Gets and sets the IncludeTimestampInLogStreamName property. Set to "true" if you wish to include a timestamp (formatted as "yyyy/MM/ddTHH.mm.ss")
+        /// as the core of the LogStreamName, set to "false" to omit the timestamp.
+        /// <para>
+        /// The default is "true".
+        /// </para>
+        /// </summary>
+        public bool IncludeTimestampInLogStreamName
+        {
+            get { return _config.IncludeTimestampInLogStreamName; }
+            set { _config.IncludeTimestampInLogStreamName = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the LogStreamNameSuffix property. The LogStreamName consists of an optional user-defined prefix segment, then a DateTimeStamp as the
         /// system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property defined here.
         /// <para>

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -233,6 +233,7 @@ namespace NLog.AWS.Logger
                 BatchPushInterval = BatchPushInterval,
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
+                IncludeTimestampInLogStreamName = IncludeTimestampInLogStreamName,
                 LogStreamNameSuffix = RenderSimpleLayout(LogStreamNameSuffix, nameof(LogStreamNameSuffix)),
                 LogStreamNamePrefix = RenderSimpleLayout(LogStreamNamePrefix, nameof(LogStreamNamePrefix)),
                 LibraryLogErrors = LibraryLogErrors,

--- a/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
@@ -87,6 +87,13 @@ namespace AWS.Logger.AspNetCore.Tests
         }
 
         [Fact]
+        public void NoTimestampTest()
+        {
+            LoggingSetup("noTimestamp.json", null);
+            SimpleLoggingTest(ConfigSection.Config.LogGroup, false);
+        }
+
+        [Fact]
         public void ExceptionMockTest()
         {
             var categoryName = "testlogging";

--- a/test/AWS.Logger.AspNetCore.Tests/noTimestamp.json
+++ b/test/AWS.Logger.AspNetCore.Tests/noTimestamp.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "LogGroup": "AWSILoggerNoTimestampTest",
+    "Region": "us-west-2",
+    "LogStreamNameSuffix": "Custom",
+    "LogStreamNamePrefix": "CustomPrefix",
+    "IncludeTimestampInLogStreamName": "false",
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information",
+      "AWS": "Debug"
+    }
+  }
+}

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -21,6 +21,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </None>
+    <None Include="NoTimestamp.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.Log4Net.Tests/NoTimestamp.config
+++ b/test/AWS.Logger.Log4Net.Tests/NoTimestamp.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<log4net>
+  <!-- A1 is set to be a ConsoleAppender -->
+  <appender name="AWS" type="AWS.Logger.Log4net.AWSAppender,AWS.Logger.Log4net" >
+
+    <LogGroup>AWSLog4NetGroupLog4NetNoTimestampTest</LogGroup>
+    <Region>us-west-2</Region>
+    <LogStreamNameSuffix>Custom</LogStreamNameSuffix>
+    <LogStreamNamePrefix>CustomPrefix</LogStreamNamePrefix>
+    <IncludeTimestampInLogStreamName>false</IncludeTimestampInLogStreamName>
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-4timestamp [%thread] %-5level %logger %ndc - %message%newline" />
+    </layout>
+  </appender>
+
+  <!-- Set root logger level to DEBUG and its only appender to A1 -->
+
+  <root>
+    <level value ="DEBUG"/>
+    <appender-ref ref="AWS" />
+  </root>
+
+</log4net>

--- a/test/AWS.Logger.Log4Net.Tests/TestClass.cs
+++ b/test/AWS.Logger.Log4Net.Tests/TestClass.cs
@@ -34,6 +34,13 @@ namespace AWS.Logger.Log4Net.Tests
         }
 
         [Fact]
+        public void NoTimestampTest()
+        {
+            GetLog4NetLogger("NoTimestamp.config", "NoTimestampTest");
+            SimpleLoggingTest("AWSLog4NetGroupLog4NetNoTimestampTest", false);
+        }
+
+        [Fact]
         public void MultiThreadTest()
         {
             GetLog4NetLogger("MultiThreadTest.config", "MultiThreadTest");

--- a/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
+++ b/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
@@ -22,6 +22,9 @@
     <None Update="Nlog.config">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
+    <None Update="NoTimestamp.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Regular.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/AWS.Logger.NLog.Tests/NoTimestamp.config
+++ b/test/AWS.Logger.NLog.Tests/NoTimestamp.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <extensions>
+    <add assembly ="NLog.AWS.Logger"/>
+  </extensions>
+  <targets>
+    <target name="AWSNLogGroup" type="AWSTarget" logGroup="AWSNLogGroupNoTimestampTest" region="us-west-2" logStreamNameSuffix="Custom" logStreamNamePrefix="CustomPrefix" includeTimestampInLogStreamName="false" />
+    <target name="loggerNoTimestamp" xsi:type="Console" layout="${callsite} ${message}" />
+  </targets>
+  <rules>
+    <logger name="loggerNoTimestamp" minlevel="Debug" writeTo="loggerNoTimestamp,AWSNLogGroup"/>
+  </rules>
+</nlog>

--- a/test/AWS.Logger.NLog.Tests/TestClass.cs
+++ b/test/AWS.Logger.NLog.Tests/TestClass.cs
@@ -33,6 +33,14 @@ namespace AWS.Logger.NLogger.Tests
         }
 
         [Fact]
+        public void NoTimestampTest()
+        {
+            CreateLoggerFromConfiguration("NoTimestamp.config");
+            Logger = LogManager.GetLogger("loggerNoTimestamp");
+            SimpleLoggingTest("AWSNLogGroupNoTimestampTest", false);
+        }
+
+        [Fact]
         public void MultiThreadTest()
         {
             CreateLoggerFromConfiguration("AWSNLogGroupMultiThreadTest.config");

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -11,10 +11,14 @@
   <ItemGroup>
     <None Remove="AWSNLogGroupMultiThreadBufferFullTest.json" />
     <None Remove="AWSNLogGroupMultiThreadTest.json" />
+    <None Remove="AWSSeriLogGroupNoTimestampTest.json" />
     <None Remove="AWSSeriLogGroupRestrictedToMinimumLevel.json" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="AWSSeriLogGroupNoTimestampTest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="AWSSeriLogGroupRestrictedToMinimumLevel.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupNoTimestampTest.json
+++ b/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupNoTimestampTest.json
@@ -1,0 +1,12 @@
+﻿{
+  "Serilog": {
+    "Using": [ "AWS.Logger.SeriLog" ],
+    "MinimumLevel": "Debug",
+    "LogGroup": "AWSSeriLogGroupNoTimestampTest",
+    "Region": "us-west-2",
+    "LogStreamNameSuffix": "Custom",
+    "LogStreamNamePrefix": "CustomPrefix",
+    "IncludeTimestampInLogStreamName": false,
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
+  }
+}

--- a/test/AWS.Logger.SeriLog.Tests/SeriLoggerTestClass.cs
+++ b/test/AWS.Logger.SeriLog.Tests/SeriLoggerTestClass.cs
@@ -38,6 +38,13 @@ namespace AWS.Logger.SeriLog.Tests
         }
 
         [Fact]
+        public void NoTimestampTest()
+        {
+            CreateLoggerFromConfiguration("AWSSeriLogGroupNoTimestampTest.json");
+            SimpleLoggingTest("AWSSeriLogGroupNoTimestampTest", false);
+        }
+
+        [Fact]
         public void MultiThreadTest()
         {
             CreateLoggerFromConfiguration("AWSSeriLogGroupMultiThreadTest.json");
@@ -97,6 +104,8 @@ namespace AWS.Logger.SeriLog.Tests
                 }).Result;
             }
             Assert.Equal(6, getLogEventsResponse.Events.Count);
+
+            _testFixture.LogGroupNameList.Add(logGroupName);
         }
 
         /// <summary>

--- a/test/AWS.Logger.UnitTests/GenerateStreamNameTests.cs
+++ b/test/AWS.Logger.UnitTests/GenerateStreamNameTests.cs
@@ -113,38 +113,106 @@ namespace AWS.Logger.UnitTests
             Assert.True(IsTokenDate(tokens[1]));
         }
 
+        [Fact]
+        public void NoTimestampSuffixSet()
+        {
+            var config = new AWSLoggerConfig
+            {
+                IncludeTimestampInLogStreamName = false,
+                LogStreamNameSuffix = "TheSuffix"
+            };
+            var streamName = AWSLoggerCore.GenerateStreamName(config);
+
+            var tokens = SplitStreamName(streamName);
+            Assert.Single(tokens);
+
+            Assert.Equal(config.LogStreamNameSuffix, tokens[0]);
+        }
+
+        [Fact]
+        public void PrefixSetNoTimestampSuffixAtDefault()
+        {
+            var config = new AWSLoggerConfig
+            {
+                IncludeTimestampInLogStreamName = false,
+                LogStreamNamePrefix = "ThePrefix"
+            };
+            var streamName = AWSLoggerCore.GenerateStreamName(config);
+
+            var tokens = SplitStreamName(streamName);
+            Assert.Equal(2, tokens.Length);
+
+            Assert.Equal(config.LogStreamNamePrefix, tokens[0]);
+            Assert.True(IsTokenGuid(tokens[1]));
+        }
+
+        [Fact]
+        public void PrefixSetNoTimestampSuffixSet()
+        {
+            var config = new AWSLoggerConfig
+            {
+                IncludeTimestampInLogStreamName = false,
+                LogStreamNamePrefix = "ThePrefix",
+                LogStreamNameSuffix = "TheSuffix"
+            };
+            var streamName = AWSLoggerCore.GenerateStreamName(config);
+
+            var tokens = SplitStreamName(streamName);
+            Assert.Equal(2, tokens.Length);
+
+            Assert.Equal(config.LogStreamNamePrefix, tokens[0]);
+            Assert.Equal(config.LogStreamNameSuffix, tokens[1]);
+        }
+
+        [Fact]
+        public void PrefixSetNoTimestampSuffixSetToNull()
+        {
+            var config = new AWSLoggerConfig
+            {
+                IncludeTimestampInLogStreamName = false,
+                LogStreamNamePrefix = "ThePrefix",
+                LogStreamNameSuffix = null
+            };
+            var streamName = AWSLoggerCore.GenerateStreamName(config);
+
+            var tokens = SplitStreamName(streamName);
+            Assert.Single(tokens);
+
+            Assert.Equal(config.LogStreamNamePrefix, tokens[0]);
+        }
+
+        [Fact]
+        public void PrefixSetNoTimestampSuffixSetToEmptyString()
+        {
+            var config = new AWSLoggerConfig
+            {
+                IncludeTimestampInLogStreamName = false,
+                LogStreamNamePrefix = "ThePrefix",
+                LogStreamNameSuffix = string.Empty
+            };
+            var streamName = AWSLoggerCore.GenerateStreamName(config);
+
+            var tokens = SplitStreamName(streamName);
+            Assert.Single(tokens);
+
+            Assert.Equal(config.LogStreamNamePrefix, tokens[0]);
+        }
+
 
         private string[] SplitStreamName(string streamName)
         {
-            const string searchToken = " - ";
-            var tokens = new List<string>();
-            int currentPos = 0;
-            int pos = streamName.IndexOf(searchToken);
-            while(pos != -1)
-            {
-                tokens.Add(streamName.Substring(currentPos, pos - currentPos));
-                currentPos = pos + searchToken.Length;
-                pos = streamName.IndexOf(searchToken, currentPos);
-            }
-
-            if(currentPos < streamName.Length)
-            {
-                tokens.Add(streamName.Substring(currentPos, streamName.Length - currentPos));
-            }
-
-            return tokens.ToArray();
+            return streamName.Split(" - ");
         }
 
         private bool IsTokenDate(string token)
         {
-            DateTime dt;
-            return DateTime.TryParseExact(token, "yyyy/MM/ddTHH.mm.ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out dt);
+            // This assumes the date separator on the system where tests are run is '/'. If it's '-' or anything else, tests will break.
+            return DateTime.TryParseExact(token, "yyyy/MM/ddTHH.mm.ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
         }
 
         private bool IsTokenGuid(string token)
         {
-            Guid guid;
-            return Guid.TryParse(token, out guid);
+            return Guid.TryParse(token, out _);
         }
     }
 }


### PR DESCRIPTION
*Issue #:* #1  

*Description of changes:*
This change addresses the long-standing request (open for nearly five years now) for a way to **not** include a timestamp in the 
name of the logstream by adding a property, IncludeTimestampInLogStreamName. This property defaults to ```true``` to preserve existing behavior - users will need to opt-in if they wish to use the new behavior.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
