### PR TITLE
Added a config parameter for Flush timeout

### DIFF
--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -175,5 +175,13 @@ namespace AWS.Logger
         /// </para>
         /// </summary>
         public string LibraryLogFileName { get; set; } = "aws-logger-errors.txt";
+
+        /// <summary>
+        /// Set how much time we will wait until flush complete
+        /// <para>
+        /// The default is 30 seconds
+        /// </para>
+        /// </summary>
+        public TimeSpan MaxWaitTimeForFlushCompletion { get; set; } = TimeSpan.FromSeconds(30);
     }
 }

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -206,7 +206,7 @@ namespace AWS.Logger.Core
                     }
 
                     // Waiting for Monitor-Task to complete flush
-                    if (!_flushCompletedEvent.Wait(TimeSpan.FromSeconds(30), _cancelStartSource.Token))
+                    if (!_flushCompletedEvent.Wait(_config.MaxWaitTimeForFlushCompletion, _cancelStartSource.Token))
                     {
                         var serviceUrl = GetServiceUrl();
                         LogLibraryServiceError(new TimeoutException($"Flush Timeout - ServiceURL={serviceUrl}, StreamName={_currentStreamName}, PendingMessages={_pendingMessageQueue.Count}, CurrentBatch={_repo.CurrentBatchMessageCount}"), serviceUrl);

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -123,5 +123,13 @@ namespace AWS.Logger
         /// </para>
         /// </summary>
         string LibraryLogFileName { get; }
+
+        /// <summary>
+        /// Set how much time we will wait until flush complete
+        /// <para>
+        /// The default is 30 seconds
+        /// </para>
+        /// </summary>
+        TimeSpan MaxWaitTimeForFlushCompletion { get; }
     }
 }

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -199,6 +199,18 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
+        /// Set how much time we will wait until flush complete
+        /// <para>
+        /// The default is 30 seconds
+        /// </para>
+        /// </summary>
+        public TimeSpan MaxWaitTimeForFlushCompletion
+        {
+            get { return _config.MaxWaitTimeForFlushCompletion; }
+            set { _config.MaxWaitTimeForFlushCompletion = value; }
+        }
+
+        /// <summary>
         /// Initialize the appender based on the options set.
         /// </summary>
         public override void ActivateOptions()

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -200,6 +200,19 @@ namespace NLog.AWS.Logger
             set { _config.LibraryLogFileName = value; }
         }
 
+        /// <summary>
+        /// Set how much time we will wait until flush complete
+        /// <para>
+        /// The default is 30 seconds
+        /// </para>
+        /// </summary>
+        public TimeSpan MaxWaitTimeForFlushCompletion
+        {
+            get { return _config.MaxWaitTimeForFlushCompletion; }
+            set { _config.MaxWaitTimeForFlushCompletion = value; }
+        }
+
+
         /// <inheritdoc/>
         protected override void InitializeTarget()
         {


### PR DESCRIPTION
*Issue #, if available:*

The original code waits up to 30 seconds until completion of flush. However, in the case of network instability or without network connection, it waits as much as 30 seconds. 30 seconds are hard-coded so it needs to be moved to Config class

*Description of changes:*

I added `IAWSLoggerConfig.MaxWaitTimeForFlushCompletion` so that we can change the timeout of the flush.
