### PR TITLE
Reduce AWS log file lock contention

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -662,14 +662,35 @@ namespace AWS.Logger.Core
         /// <summary>
         /// Write Exception details to the file specified with the filename
         /// </summary>
+        public static void LogLibraryError(Exception? ex, string LibraryLogFileName)
+        {
+            try
+            {
+                StringBuilder sb = new StringBuilder(512);
+
+                sb.AppendLine("Log Entry : ");
+
+                sb.AppendLine(DateTime.Now.ToString());
+
+                sb.AppendLine("  :");
+
+                sb.Append("  :");
+                sb.AppendLine(ex.ToString());
+
+                sb.AppendLine("-------------------------------");
+
+                WriteToFile(LibraryLogFileName, sb.ToString());
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Exception caught when writing error log to file" + e.ToString());
+            }
+        }
+
+        static ReaderWriterLock locker = new ReaderWriterLock();
+
         private static void WriteToFile(string fileName, string text)
         {
-            //
-            // The locker ensures within process atomic access,
-            // but the same file can be accessed from multiple processes
-            // at the same time. On Windows, this will raise an
-            // IOException. Try again a number of times.
-            //
             const int TRY_SLEEP_INTERVAL_MS = 50;
             const int MAX_TRIES = 25;
 


### PR DESCRIPTION
Increase scaleability of AWS-error logging, reducing file lock duration on Windows and increasing likeliness that logging will succeed with large log files and multiple Windows OS-processes or threads within one process competing for access to the log file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
