### PR TITLE
Add a flush timeout to config and use it instead of hardcoded 30s

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Extensions.Configuration
         internal const string LOG_STREAM_NAME_PREFIX = "LogStreamNamePrefix";
         internal const string LIBRARY_LOG_FILE_NAME = "LibraryLogFileName";
         internal const string LIBRARY_LOG_ERRORS = "LibraryLogErrors";
+        internal const string FLUSH_TIMEOUT = "FlushTimeout";
 
         private const string INCLUDE_LOG_LEVEL_KEY = "IncludeLogLevel";
         private const string INCLUDE_CATEGORY_KEY = "IncludeCategory";
@@ -187,6 +188,10 @@ namespace Microsoft.Extensions.Configuration
             if (loggerConfigSection[LIBRARY_LOG_ERRORS] != null)
             {
                 Config.LibraryLogErrors = Boolean.Parse(loggerConfigSection[LIBRARY_LOG_ERRORS]);
+            }
+            if (loggerConfigSection[FLUSH_TIMEOUT] != null)
+            {
+                Config.FlushTimeout = TimeSpan.FromMilliseconds(Int32.Parse(loggerConfigSection[FLUSH_TIMEOUT]));
             }
 
             if (loggerConfigSection[INCLUDE_LOG_LEVEL_KEY] != null)

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -107,7 +107,7 @@ namespace AWS.Logger
 
         /// <summary>
         /// Gets and sets the MaxQueuedMessages property. This specifies the maximum number of log messages that could be stored in-memory. MaxQueuedMessages 
-        /// dictates the total number of log messages that can be stored in-memory. If this exceeded, incoming log messages will be dropped.
+        /// dictates the total number of log messages that can be stored in-memory. If this is exceeded, incoming log messages will be dropped.
         /// <para>
         /// The default is 10000.
         /// </para>
@@ -175,5 +175,14 @@ namespace AWS.Logger
         /// </para>
         /// </summary>
         public string LibraryLogFileName { get; set; } = "aws-logger-errors.txt";
+
+        /// <summary>
+        /// Gets the FlushTimeout property. The value is in milliseconds. When performing a flush of the in-memory queue this is the maximum period of time allowed to send the remaining
+        /// messages before it will be aborted. If this is exceeded, incoming log messages will be dropped.
+        /// <para>
+        /// The default is 30000 milliseconds.
+        /// </para>
+        /// </summary>
+        public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromMilliseconds(30000);
     }
 }

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -206,7 +206,7 @@ namespace AWS.Logger.Core
                     }
 
                     // Waiting for Monitor-Task to complete flush
-                    if (!_flushCompletedEvent.Wait(TimeSpan.FromSeconds(30), _cancelStartSource.Token))
+                    if (!_flushCompletedEvent.Wait(_config.FlushTimeout, _cancelStartSource.Token))
                     {
                         var serviceUrl = GetServiceUrl();
                         LogLibraryServiceError(new TimeoutException($"Flush Timeout - ServiceURL={serviceUrl}, StreamName={_currentStreamName}, PendingMessages={_pendingMessageQueue.Count}, CurrentBatch={_repo.CurrentBatchMessageCount}"), serviceUrl);

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -81,7 +81,7 @@ namespace AWS.Logger
 
         /// <summary>
         /// Gets and sets the MaxQueuedMessages property. This specifies the maximum number of log messages that could be stored in-memory. MaxQueuedMessages 
-        /// dictates the total number of log messages that can be stored in-memory. If this exceeded, incoming log messages will be dropped.
+        /// dictates the total number of log messages that can be stored in-memory. If this is exceeded, incoming log messages will be dropped.
         /// <para>
         /// The default is 10000.
         /// </para>
@@ -117,11 +117,20 @@ namespace AWS.Logger
         bool LibraryLogErrors { get; set; }
         
         /// <summary>
-        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
+        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be written into.
         /// <para>
         /// The default is going to "aws-logger-errors.txt".
         /// </para>
         /// </summary>
         string LibraryLogFileName { get; }
+
+        /// <summary>
+        /// Gets the FlushTimeout property. The value is in milliseconds. When performing a flush of the in-memory queue this is the maximum period of time allowed to send the remaining
+        /// messages before it will be aborted. If this is exceeded, incoming log messages will be dropped.
+        /// <para>
+        /// The default is 30000 milliseconds.
+        /// </para>
+        /// </summary>
+        TimeSpan FlushTimeout { get; }
     }
 }

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -137,7 +137,7 @@ namespace AWS.Logger.Log4net
 
         /// <summary>
         /// Gets and sets the MaxQueuedMessages property. This specifies the maximum number of log messages that could be stored in-memory. MaxQueuedMessages 
-        /// dictates the total number of log messages that can be stored in-memory. If this exceeded, incoming log messages will be dropped.
+        /// dictates the total number of log messages that can be stored in-memory. If this is exceeded, incoming log messages will be dropped.
         /// <para>
         /// The default is 10000.
         /// </para>
@@ -185,9 +185,22 @@ namespace AWS.Logger.Log4net
             get { return _config.LibraryLogErrors; }
             set { _config.LibraryLogErrors = value; }
         }
-        
+
         /// <summary>
-        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
+        /// Gets and sets the FlushTimeout property. The value is in milliseconds. When performing a flush of the in-memory queue this is the maximum period of time allowed to send the remaining
+        /// messages before it will be aborted. If this is exceeded, incoming log messages will be dropped.
+        /// <para>
+        /// The default is 30000 milliseconds.
+        /// </para>
+        /// </summary>
+        public TimeSpan FlushTimeout
+        {
+            get { return _config.FlushTimeout; }
+            set { _config.FlushTimeout = value; }
+        }
+
+        /// <summary>
+        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be written into.
         /// <para>
         /// The default is going to "aws-logger-errors.txt".
         /// </para>
@@ -220,10 +233,11 @@ namespace AWS.Logger.Log4net
                 BatchPushInterval = BatchPushInterval,
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
-				LogStreamNameSuffix = LogStreamNameSuffix,
+                LogStreamNameSuffix = LogStreamNameSuffix,
                 LogStreamNamePrefix = LogStreamNamePrefix,
                 LibraryLogErrors = LibraryLogErrors,
-				LibraryLogFileName = LibraryLogFileName
+                LibraryLogFileName = LibraryLogFileName,
+                FlushTimeout = FlushTimeout
             };
             _core = new AWSLoggerCore(config, "Log4net");
         }

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -25,6 +25,7 @@ namespace AWS.Logger.SeriLog
         internal const string LOG_STREAM_NAME_PREFIX = "Serilog:LogStreamNamePrefix";
         internal const string LIBRARY_LOG_FILE_NAME = "Serilog:LibraryLogFileName";
         internal const string LIBRARY_LOG_ERRORS = "Serilog:LibraryLogErrors";
+        internal const string FLUSH_TIMEOUT = "Serilog:FlushTimeout";
 
         /// <summary>
         /// AWSSeriLogger target that is called when the customer is using 
@@ -88,6 +89,10 @@ namespace AWS.Logger.SeriLog
             if (configuration[LIBRARY_LOG_ERRORS] != null)
             {
                 config.LibraryLogErrors = Boolean.Parse(configuration[LIBRARY_LOG_ERRORS]);
+            }
+            if (configuration[FLUSH_TIMEOUT] != null)
+            {
+                config.FlushTimeout = TimeSpan.FromMilliseconds(Int32.Parse(configuration[FLUSH_TIMEOUT]));
             }
             return AWSSeriLog(loggerConfiguration, config, iFormatProvider, textFormatter, restrictedToMinimumLevel);
         }

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -139,7 +139,7 @@ namespace NLog.AWS.Logger
 
         /// <summary>
         /// Gets and sets the MaxQueuedMessages property. This specifies the maximum number of log messages that could be stored in-memory. MaxQueuedMessages 
-        /// dictates the total number of log messages that can be stored in-memory. If this exceeded, incoming log messages will be dropped.
+        /// dictates the total number of log messages that can be stored in-memory. If this is exceeded, incoming log messages will be dropped.
         /// <para>
         /// The default is 10000.
         /// </para>
@@ -189,7 +189,7 @@ namespace NLog.AWS.Logger
         }
 
         /// <summary>
-        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be wriiten into.
+        /// Gets and sets the LibraryLogFileName property. This is the name of the file into which errors from the AWS.Logger.Core library will be written into.
         /// <para>
         /// The default is "aws-logger-errors.txt".
         /// </para>
@@ -198,6 +198,19 @@ namespace NLog.AWS.Logger
         {
             get { return _config.LibraryLogFileName; }
             set { _config.LibraryLogFileName = value; }
+        }
+
+        /// <summary>
+        /// Gets the FlushTimeout property. The value is in milliseconds. When performing a flush of the in-memory queue this is the maximum period of time allowed to send the remaining
+        /// messages before it will be aborted. If this is exceeded, incoming log messages will be dropped.
+        /// <para>
+        /// The default is 30000 milliseconds.
+        /// </para>
+        /// </summary>
+        public TimeSpan FlushTimeout
+        {
+            get { return _config.FlushTimeout; }
+            set { _config.FlushTimeout = value; }
         }
 
         /// <inheritdoc/>
@@ -223,7 +236,8 @@ namespace NLog.AWS.Logger
                 LogStreamNameSuffix = RenderSimpleLayout(LogStreamNameSuffix, nameof(LogStreamNameSuffix)),
                 LogStreamNamePrefix = RenderSimpleLayout(LogStreamNamePrefix, nameof(LogStreamNamePrefix)),
                 LibraryLogErrors = LibraryLogErrors,
-                LibraryLogFileName = LibraryLogFileName
+                LibraryLogFileName = LibraryLogFileName,
+                FlushTimeout = FlushTimeout
             };
             _core = new AWSLoggerCore(config, "NLog");
             _core.LogLibraryAlert += AwsLogLibraryAlert;


### PR DESCRIPTION
*Issue #:* #180 

*Description of changes:*
Add a configurable flush timeout, replacing hard coded 30s.

___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
