### PR TITLE
Added LogStreamNameUniqueKey to config. Allows resumption of logging to stream from suspended tasks.

### DIFF
--- a/samples/NLog/ProgrammaticConfigurationExample/Program.cs
+++ b/samples/NLog/ProgrammaticConfigurationExample/Program.cs
@@ -16,15 +16,15 @@ namespace ProgrammaticConfigurationExample
     {
         static void Main(string[] args)
         {
-            ConfigureNLog();
-
+            ConfigureNLog(args.Length > 0 ? args[0] : null);
+            
             Logger logger = LogManager.GetCurrentClassLogger();
             logger.Info("Check the AWS Console CloudWatch Logs console in us-east-1");
             logger.Info("to see messages in the log streams for the");
             logger.Info("log group NLog.ProgrammaticConfigurationExample");
         }
 
-        static void ConfigureNLog()
+        static void ConfigureNLog(string Key = null)
         {
             var config = new LoggingConfiguration();
 
@@ -36,6 +36,13 @@ namespace ProgrammaticConfigurationExample
                 LogGroup = "NLog.ProgrammaticConfigurationExample",
                 Region = "us-east-1"
             };
+
+            if (Key != null)
+            {
+                awsTarget.LogStreamNameUniqueKey = Key;
+                awsTarget.LogStreamNameSuffix = string.Empty;
+            };
+
             config.AddTarget("aws", awsTarget);
 
             config.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, consoleTarget));

--- a/samples/NLog/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
+++ b/samples/NLog/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
@@ -33,11 +33,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NLog.4.4.0\lib\net45\NLog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\NLog.4.7.15\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/samples/NLog/ProgrammaticConfigurationExample/packages.config
+++ b/samples/NLog/ProgrammaticConfigurationExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.4.0" targetFramework="net45" />
+  <package id="NLog" version="4.7.15" targetFramework="net45" />
 </packages>

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -151,6 +151,15 @@ namespace AWS.Logger
         public string LogStreamNameSuffix { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
+        /// Sets a unique key for this instance. Keys should be unique to the instance to prevent multiple instances logging to the same stream.
+        /// CAUTION: This should be unique to a log instance to prevent conflicts between instances.
+        /// <para>
+        /// The default is DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")
+        /// </para>
+        /// </summary>
+        public string LogStreamNameUniqueKey { get; set; } = DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss");
+
+        /// <summary>
         /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix (that can be set here)
         /// followed by a DateTimeStamp as the prefix, and a user defined suffix value
         /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -99,6 +99,15 @@ namespace AWS.Logger
         string LogStreamNameSuffix { get; }
 
         /// <summary>
+        /// Sets a unique key for this instance. Keys should be unique to the instance to prevent multiple instances logging to the same stream.
+        /// CAUTION: This should be unique to a log instance to prevent conflicts between instances.
+        /// <para>
+        /// The default is DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")
+        /// </para>
+        /// </summary>
+        string LogStreamNameUniqueKey { get; }
+
+        /// <summary>
         /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined LogStreamNamePrefix (that can be set here)
         /// followed by a DateTimeStamp as the prefix, and a user defined suffix value
         /// The LogstreamName then follows the pattern '[LogStreamNamePrefix]-[DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")]-[LogStreamNameSuffix]'

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -162,6 +162,19 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
+        /// Sets a unique key for this instance. Keys should be unique to the instance to prevent multiple instances logging to the same stream.
+        /// CAUTION: This should be unique to a log instance to prevent conflicts between instances.
+        /// <para>
+        /// The default is DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")
+        /// </para>
+        /// </summary>
+        public string LogStreamNameUniqueKey
+        {
+            get { return _config.LogStreamNameUniqueKey; }
+            set { _config.LogStreamNameUniqueKey = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined prefix segment (defined here), then a
         /// DateTimeStamp as the system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property.
         /// <para>

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -164,6 +164,19 @@ namespace NLog.AWS.Logger
         }
 
         /// <summary>
+        /// Sets a unique key for this instance. Keys should be unique to the instance to prevent multiple instances logging to the same stream.
+        /// CAUTION: This should be unique to a log instance to prevent conflicts between instances.
+        /// <para>
+        /// The default is DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")
+        /// </para>
+        /// </summary>
+        public string LogStreamNameUniqueKey
+        {
+            get { return _config.LogStreamNameUniqueKey; }
+            set { _config.LogStreamNameUniqueKey = value; }
+        }
+
+        /// <summary>
         /// Gets and sets the LogStreamNamePrefix property. The LogStreamName consists of an optional user-defined prefix segment (defined here), then a
         /// DateTimeStamp as the system-defined prefix segment, and a user defined suffix value that can be set using the LogStreamNameSuffix property.
         /// <para>
@@ -234,6 +247,7 @@ namespace NLog.AWS.Logger
                 BatchSizeInBytes = BatchSizeInBytes,
                 MaxQueuedMessages = MaxQueuedMessages,
                 LogStreamNameSuffix = RenderSimpleLayout(LogStreamNameSuffix, nameof(LogStreamNameSuffix)),
+                LogStreamNameUniqueKey = RenderSimpleLayout(LogStreamNameUniqueKey, nameof(LogStreamNameUniqueKey)),
                 LogStreamNamePrefix = RenderSimpleLayout(LogStreamNamePrefix, nameof(LogStreamNamePrefix)),
                 LibraryLogErrors = LibraryLogErrors,
                 LibraryLogFileName = LibraryLogFileName,


### PR DESCRIPTION
Added `LogStreamNameUniqueKey` to the config options, defaulting to the current format of `DateTime.Now.ToString("yyyy/MM/ddTHH.mm.ss")`

This allows a developer to provide their own unique key for the log stream, rather than being forced to use the current format. For example a task can resume logging to the same log stream it previously used if it was suspended.

`UploadSequenceToken` is first obtained by describing the LogStream. If the LogStream does not exist, a new LogStream is created.

To demonstrate this, I have added an option to the ProgrammaticConfigurationExample NLog sample that takes the first command line argument, and uses this as the unique key. 

Running the sample from the command line with the following arguments will add two log streams to the sample log group, with Task1 resuming it's previous log stream.

```
ProgrammaticConfigurationExample.exe Task1
ProgrammaticConfigurationExample.exe Task2
ProgrammaticConfigurationExample.exe Task1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
