### PR TITLE
Avoid infinite log resending if exceptions happen during the log-sending process

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -92,6 +92,7 @@ namespace AWS.Logger.Core
                 {
                     awsConfig.UseHttp = true;
                 }
+                awsConfig.AuthenticationRegion = _config.Region;
             }
             else
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. We drop the logs in the log batch if the current log batch causes exceptions in the log-sending process 
2. we set the auth region by the config region if the service url is used

For 1., we did this because we observed that our log batch causes the [over 24 hours spanning problem ](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/put_log_events.html#put-log-events)
and since the monitor is not stopped, it just resends the log batch forever.

For 2., we did this because we got a problem with the auth region setup

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
