### PR TITLE
Implementing Retention Policy to Cloudwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ The practice of granting least privilege access is recommended when setting up c
 
 For more information and a sample JSON policy template, please see [Amazon CloudWatch Logs and .NET Logging Frameworks](https://aws.amazon.com/blogs/developer/amazon-cloudwatch-logs-and-net-logging-frameworks/) on the AWS Developer Blog.
 
+### Optional IAM Permissions
+
+The following [IAM](https://aws.amazon.com/iam) permissions are optional depending on the configured features of the logger.
+
+| Feature                                                                       | IAM Permission(s) for feature | Configuration Setting         |
+|-------------------------------------------------------------------------------|-------------------------------|-------------------------------|
+| [Set new log group retention policy](#setting-new-log-group-retention-policy) | `logs:PutRetentionPolicy`     | `NewLogGroupRetentionInDays`  |
 
 ### Why can't the Log Stream name be configured?
 
@@ -44,6 +51,21 @@ the marker maintained within the process goes out of sync. This generates errors
 message causing performance issues.
 
 To view logs across all log streams it is recommended to use the [Logs Insight](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) feature for Cloud Watch Logs.
+
+### Setting new Log Group Retention Policy
+
+These libraries support setting a [log retention policy](https://docs.aws.amazon.com/managedservices/latest/userguide/log-customize-retention.html) 
+on any CloudWatch Log Groups which they create.  This feature is enabled using the NewLogGroupRetentionInDays configuration property. 
+The DisableLogGroupCreation configuration property must not be set to true. Retention policies configured in this manner 
+are only applied to _new_ Log Groups created directly by these libraries. By default no retention policy is applied to newly created Log Groups.
+
+
+Note that any value of NewLogGroupRetentionInDays which is not one supported by CloudWatch [which can be found here](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#API_PutRetentionPolicy_RequestSyntax) - and listed below - is a configuration error which will result
+in a non-fatal error applying the policy. The application and logging will continue however no retention policy will be applied. 
+ 
+```csharp
+null, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653
+```
 
 ## Supported Logging Frameworks
 

--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Extensions.Configuration
 
         internal const string LOG_GROUP = "LogGroup";
         internal const string DISABLE_LOG_GROUP_CREATION = "DisableLogGroupCreation";
+        internal const string NEW_LOG_GROUP_RETENTION_IN_DAYS = "NewLogGroupRetentionInDays";
         internal const string REGION = "Region";
         internal const string SERVICEURL = "ServiceUrl";
         internal const string PROFILE = "Profile";
@@ -145,6 +146,7 @@ namespace Microsoft.Extensions.Configuration
         {
             Config.LogGroup = loggerConfigSection[LOG_GROUP];
             Config.DisableLogGroupCreation = loggerConfigSection.GetValue<bool>(DISABLE_LOG_GROUP_CREATION);
+            Config.NewLogGroupRetentionInDays = loggerConfigSection.GetValue<int?>(NEW_LOG_GROUP_RETENTION_IN_DAYS);
             if (loggerConfigSection[REGION] != null)
             {
                 Config.Region = loggerConfigSection[REGION];

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -36,6 +36,22 @@ namespace AWS.Logger
         public bool DisableLogGroupCreation { get; set; }
 
         /// <summary>
+        /// Specifies the days to retain events in log groups which are created by this logger, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// and <see cref="DisableLogGroupCreation"/> is not <c>true</c>. Requires logs:PutRetentionPolicy permission to apply the retention policy to
+        /// newly created log groups. The default value of <c>null</c> will not apply a retention policy to new log groups.
+        /// <para>
+        /// Note that log groups which already exist will not have this retention policy applied for startup performance reasons.
+        /// </para>
+        /// <para>
+        /// Possible values could be found in the CloudWatchLogs API reference at https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#API_PutRetentionPolicy_RequestSyntax
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Note that invalid retention policy values will result in the policy not being applied, however this error is non-fatal and the application and will continue without the policy.
+        /// </remarks>
+        public int? NewLogGroupRetentionInDays { get; set; } = null;
+
+        /// <summary>
         /// Gets and sets the Profile property. The profile is used to look up AWS credentials in the profile store.
         /// <para>
         /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -22,6 +22,22 @@ namespace AWS.Logger
         /// When creation of log groups is disabled, logs:DescribeLogGroups permission is NOT required.
         /// </summary>
         bool DisableLogGroupCreation { get; set; }
+        
+        /// <summary>
+        /// Specifies the days to retain events in log groups which are created by this logger, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// and <see cref="DisableLogGroupCreation"/> is not <c>true</c>. Requires logs:PutRetentionPolicy permission to apply the retention policy to
+        /// newly created log groups. The default value of <c>null</c> will not apply a retention policy to new log groups.
+        /// <para>
+        /// Note that log groups which already exist will not have this retention policy applied for startup performance reasons.
+        /// </para>
+        /// <para>
+        /// Possible values could be found in the CloudWatchLogs API reference at https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#API_PutRetentionPolicy_RequestSyntax
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Note that invalid retention policy values will result in the policy not being applied, however this error is non-fatal and the application and will continue without the policy.
+        /// </remarks>
+        int? NewLogGroupRetentionInDays { get; set; }
 
         /// <summary>
         /// Gets the Profile property. The profile is used to look up AWS credentials in the profile store.

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -45,6 +45,22 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
+        /// Specifies the days to retain events in log groups which are created by this logger, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// and <see cref="DisableLogGroupCreation"/> is not <c>true</c>. Requires logs:PutRetentionPolicy permission to apply the retention policy to
+        /// newly created log groups. The default value of <c>null</c> will not apply a retention policy to new log groups.
+        /// <para>
+        /// Note that log groups which already exist will not have this retention policy applied for startup performance reasons.
+        /// </para>
+        /// <para>
+        /// Possible values could be found in the CloudWatchLogs API reference at https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#API_PutRetentionPolicy_RequestSyntax
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Note that invalid retention policy values will result in the policy not being applied, however this error is non-fatal and the application and will continue without the policy.
+        /// </remarks>
+        public int? NewLogGroupRetentionInDays { get; set; } = null;
+
+        /// <summary>
         /// Gets and sets the Profile property. The profile is used to look up AWS credentials in the profile store.
         /// <para>
         /// For understanding how credentials are determine view the top level documentation for AWSLoggerConfig class.

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -14,6 +14,7 @@ namespace AWS.Logger.SeriLog
     {
         internal const string LOG_GROUP = "Serilog:LogGroup";
         internal const string DISABLE_LOG_GROUP_CREATION = "Serilog:DisableLogGroupCreation";
+        internal const string NEW_LOG_GROUP_RETENTION_IN_DAYS = "Serilog:NewLogGroupRetentionInDays";
         internal const string REGION = "Serilog:Region";
         internal const string SERVICEURL = "Serilog:ServiceUrl";
         internal const string PROFILE = "Serilog:Profile";
@@ -45,6 +46,10 @@ namespace AWS.Logger.SeriLog
             if (configuration[DISABLE_LOG_GROUP_CREATION] != null)
             {
                 config.DisableLogGroupCreation = bool.Parse(configuration[DISABLE_LOG_GROUP_CREATION]);
+            }
+            if (configuration[NEW_LOG_GROUP_RETENTION_IN_DAYS] is string s && int.TryParse(s, out var retentionInDays))
+            {
+                config.NewLogGroupRetentionInDays = retentionInDays;
             }
             if (configuration[REGION] != null)
             {

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -48,6 +48,22 @@ namespace NLog.AWS.Logger
             get { return _config.DisableLogGroupCreation; }
             set { _config.DisableLogGroupCreation = value; }
         }
+        
+        /// <summary>
+        /// Specifies the days to retain events in log groups which are created by this logger, if the one specified by <see cref="LogGroup"/> doesn't already exist
+        /// and <see cref="DisableLogGroupCreation"/> is not <c>true</c>. Requires logs:PutRetentionPolicy permission to apply the retention policy to
+        /// newly created log groups. The default value of <c>null</c> will not apply a retention policy to new log groups.
+        /// <para>
+        /// Note that log groups which already exist will not have this retention policy applied for startup performance reasons.
+        /// </para>
+        /// <para>
+        /// Possible values could be found in the CloudWatchLogs API reference at https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#API_PutRetentionPolicy_RequestSyntax
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Note that invalid retention policy values will result in the policy not being applied, however this error is non-fatal and the application and will continue without the policy.
+        /// </remarks>
+        public int? NewLogGroupRetentionInDays { get; set; } = null;
 
         /// <summary>
         /// Gets and sets the Profile property. The profile is used to look up AWS credentials in the profile store.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Implement retention policy application in the core cloudwatch logger.

Taking another crack based on the changes from @DebashishSaha in this PR https://github.com/aws/aws-logging-dotnet/pull/208 to address @normj's  performance concerns related to performing a blocking application of the retention policy in `LogEventTransmissionSetup`. 

Instead iff a new log group is created _and_ a retention policy is configured to be created, a background task is started which then applies said policy to the newly created group.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
![image](https://github.com/aws/aws-logging-dotnet/assets/33221227/0b2f84a1-2a09-4ec2-8088-9b5e6e9cdd66)
