### PR TITLE
chore: Version bump

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
+++ b/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
@@ -21,7 +21,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -22,7 +22,7 @@
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
+++ b/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
@@ -21,7 +21,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
+++ b/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
@@ -22,7 +22,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:* Version bump to release #229 and #228 

**Note:** I did not version bump Serilog even though there is an AWS.Logger.Core change. Given the nature of the change (removing unused code), I didn't think it was worth it but let me know if you disagree.

Proposed changelog entries:
```
AWS.Logger.Log4Net
  * Correctly honor NewLogGroupRetentionInDays during initialization
NLog.AWS.Logger
  * Correctly honor NewLogGroupRetentionInDays during initialization
AWS.Logger.AspNetCore
  * Update NullExternalScopeProvider/NullScope handling for newer Microsoft.Extensions.Logging.Abstractions
AWS.Logger.Core
  * Remove unused code from old .NET Standard 1.5 target

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
