### PR TITLE
Update targets and dependencies of tests and solutions

### DIFF
--- a/samples/AspNetCore/ConsoleSample/ConsoleSample.csproj
+++ b/samples/AspNetCore/ConsoleSample/ConsoleSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>ConsoleSample</AssemblyName>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/AspNetCore/WebSample/Startup.cs
+++ b/samples/AspNetCore/WebSample/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace WebSample
@@ -32,7 +33,7 @@ namespace WebSample
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             // Example Logging
             _logger.LogInformation("Check the AWS Console CloudWatch Logs console in us-east-1");

--- a/samples/AspNetCore/WebSample/WebSample.csproj
+++ b/samples/AspNetCore/WebSample/WebSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Serilog/SerilogTestCode/SerilogTestCode.csproj
+++ b/samples/Serilog/SerilogTestCode/SerilogTestCode.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWS.Logger.SeriLog" Version="1.4.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="AWS.Logger.SeriLog" Version="3.3.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/Serilog/SerilogTestCodeFromConfig/SerilogTestCodeFromConfig.csproj
+++ b/samples/Serilog/SerilogTestCodeFromConfig/SerilogTestCodeFromConfig.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWS.Logger.SeriLog" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="AWS.Logger.SeriLog" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Serilog/SerilogTestCodeFromConfigRestrictedToMinimumLevel/SerilogTestCodeFromConfigRestrictedToMinimumLevel.csproj
+++ b/samples/Serilog/SerilogTestCodeFromConfigRestrictedToMinimumLevel/SerilogTestCodeFromConfigRestrictedToMinimumLevel.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWS.Logger.SeriLog" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="AWS.Logger.SeriLog" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
+++ b/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
@@ -21,7 +21,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\awssdk.dll.snk</AssemblyOriginatorKeyFile>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.AspNetCore/NullExternalScopeProvider.cs
+++ b/src/AWS.Logger.AspNetCore/NullExternalScopeProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 using System;
 
 namespace AWS.Logger.AspNetCore
@@ -27,6 +26,15 @@ namespace AWS.Logger.AspNetCore
         IDisposable IExternalScopeProvider.Push(object state)
         {
             return NullScope.Instance;
+        }
+
+        private class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new NullScope();
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
+++ b/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>AWS.Logger.AspNetCore.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,22 +16,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
@@ -103,7 +103,7 @@ namespace AWS.Logger.AspNetCore.Tests
         /// onto the FakeCoreLogger. The results are then verified.
         /// </summary>
         [Fact]
-        public void MultiThreadTestMock()
+        public async Task MultiThreadTestMock()
         {
             var categoryName = "testlogging";
             var coreLogger = new FakeCoreLogger();
@@ -118,7 +118,7 @@ namespace AWS.Logger.AspNetCore.Tests
                 tasks.Add(Task.Factory.StartNew(() => LogMessages(logMessageCount)));
                 actualCount = actualCount + logMessageCount;
             }
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
 
             Assert.Equal(actualCount, coreLogger.ReceivedMessages.Count);
         }

--- a/test/AWS.Logger.AspNetCore.Tests/TestFilter.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestFilter.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Hosting;
 using Xunit;
 using System;
-using Microsoft.Extensions.DependencyInjection;
-using System.IO;
 using System.Reflection;
 using System.Linq;
 

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.Log4Net.FilterTests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,15 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
+	
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="log4net" Version="2.0.12" />
   </ItemGroup>

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.Log4Net.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,13 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
+++ b/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.NLog.FilterTests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,13 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-  
 </Project>

--- a/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
+++ b/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.NLog.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,13 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-  
 </Project>

--- a/test/AWS.Logger.NLog.Tests/TestClass.cs
+++ b/test/AWS.Logger.NLog.Tests/TestClass.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Amazon.CloudWatchLogs.Model;
 using AWS.Logger.TestUtils;
 using NLog;
@@ -49,7 +50,7 @@ namespace AWS.Logger.NLogger.Tests
         }
 
         [Fact]
-        public void MessageHasToBeBrokenUp()
+        public async Task MessageHasToBeBrokenUp()
         {
             string logGroupName = "AWSNLogGroupEventSizeExceededTest";
 
@@ -64,20 +65,20 @@ namespace AWS.Logger.NLogger.Tests
             if (NotifyLoggingCompleted(logGroupName, "LASTMESSAGE"))
             {
                 DescribeLogStreamsResponse describeLogstreamsResponse =
-                Client.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
+                await Client.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
                 {
                     Descending = true,
                     LogGroupName = logGroupName,
                     OrderBy = "LastEventTime"
-                }).Result;
+                });
 
                 // Wait for the large messages to propagate
                 Thread.Sleep(5000);
-                getLogEventsResponse = Client.GetLogEventsAsync(new GetLogEventsRequest
+                getLogEventsResponse = await Client.GetLogEventsAsync(new GetLogEventsRequest
                 {
                     LogGroupName = logGroupName,
                     LogStreamName = describeLogstreamsResponse.LogStreams[0].LogStreamName
-                }).Result;
+                });
             }
             _testFixture.LogGroupNameList.Add(logGroupName);
             Assert.Equal(4, getLogEventsResponse.Events.Count);

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>AWS.Logger.SeriLog.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
  
   <ItemGroup>
@@ -35,15 +37,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
+++ b/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.TestUtils</AssemblyName>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.305.6" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
  
 </Project>

--- a/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
+++ b/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
     <AssemblyName>AWS.Logger.UnitTests</AssemblyName>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -15,13 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.UnitTests/DisableLogGroupCreationTests.cs
+++ b/test/AWS.Logger.UnitTests/DisableLogGroupCreationTests.cs
@@ -60,7 +60,7 @@ namespace AWS.Logger.UnitTests
                     core.Flush();
                 });
 
-                await Task.WhenAny(tsk, resourceNotFoundPromise.Task).ConfigureAwait(false);
+                await Task.WhenAny(tsk, resourceNotFoundPromise.Task);
                 resourceNotFoundPromise.TrySetResult(false);
                 Assert.True(await resourceNotFoundPromise.Task);
 
@@ -72,7 +72,7 @@ namespace AWS.Logger.UnitTests
                 _testFixure.LogGroupNameList.Add(logGroupName);
 
                 // wait for the flusher task to finish, which should actually proceed OK, now that we've created the expected log group.
-                await tsk.ConfigureAwait(false);
+                await tsk;
                 core.Close();
             }
         }


### PR DESCRIPTION
*Description of changes:*
Clean up some bit rot 
* Update test and samples to use modern .NET targets and dependencies.
* Fix all warnings in the solution and turn on warnings as errors to avoid getting more
* Fix VS test discovery by fixing the test adaptors.
* Fix an issue with the ILogger adaptor referencing an "internal" type that is not longer in newer versions of .NET. This is the one functional change in the released packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
