### PR TITLE
Update tests and samples to modern .NET versions and clean up all warnings

### DIFF
--- a/samples/AspNetCore/ConsoleSample/ConsoleSample.csproj
+++ b/samples/AspNetCore/ConsoleSample/ConsoleSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>ConsoleSample</AssemblyName>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/AspNetCore/WebSample/Startup.cs
+++ b/samples/AspNetCore/WebSample/Startup.cs
@@ -33,7 +33,7 @@ namespace WebSample
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             // Example Logging
             _logger.LogInformation("Check the AWS Console CloudWatch Logs console in us-east-1");

--- a/samples/AspNetCore/WebSample/WebSample.csproj
+++ b/samples/AspNetCore/WebSample/WebSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Serilog/SerilogTestCode/SerilogTestCode.csproj
+++ b/samples/Serilog/SerilogTestCode/SerilogTestCode.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWS.Logger.SeriLog" Version="1.4.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="AWS.Logger.SeriLog" Version="3.3.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/Serilog/SerilogTestCodeFromConfig/SerilogTestCodeFromConfig.csproj
+++ b/samples/Serilog/SerilogTestCodeFromConfig/SerilogTestCodeFromConfig.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWS.Logger.SeriLog" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="AWS.Logger.SeriLog" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Serilog/SerilogTestCodeFromConfigRestrictedToMinimumLevel/SerilogTestCodeFromConfigRestrictedToMinimumLevel.csproj
+++ b/samples/Serilog/SerilogTestCodeFromConfigRestrictedToMinimumLevel/SerilogTestCodeFromConfigRestrictedToMinimumLevel.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWS.Logger.SeriLog" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="AWS.Logger.SeriLog" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
+++ b/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>AWS.Logger.AspNetCore.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,17 +16,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
@@ -103,7 +103,7 @@ namespace AWS.Logger.AspNetCore.Tests
         /// onto the FakeCoreLogger. The results are then verified.
         /// </summary>
         [Fact]
-        public void MultiThreadTestMock()
+        public async Task MultiThreadTestMock()
         {
             var categoryName = "testlogging";
             var coreLogger = new FakeCoreLogger();
@@ -118,7 +118,7 @@ namespace AWS.Logger.AspNetCore.Tests
                 tasks.Add(Task.Factory.StartNew(() => LogMessages(logMessageCount)));
                 actualCount = actualCount + logMessageCount;
             }
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
 
             Assert.Equal(actualCount, coreLogger.ReceivedMessages.Count);
         }

--- a/test/AWS.Logger.AspNetCore.Tests/TestFilter.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestFilter.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Hosting;
 using Xunit;
 using System;
-using Microsoft.Extensions.DependencyInjection;
-using System.IO;
 using System.Reflection;
 using System.Linq;
 

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
  
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.Log4Net.FilterTests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,19 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
+	
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="log4net" Version="2.0.15" />
   </ItemGroup>

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.Log4Net.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,17 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
+++ b/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.NLog.FilterTests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,17 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-  
 </Project>

--- a/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
+++ b/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.NLog.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,17 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-  
 </Project>

--- a/test/AWS.Logger.NLog.Tests/TestClass.cs
+++ b/test/AWS.Logger.NLog.Tests/TestClass.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Amazon.CloudWatchLogs.Model;
 using AWS.Logger.TestUtils;
 using NLog;
@@ -49,7 +50,7 @@ namespace AWS.Logger.NLogger.Tests
         }
 
         [Fact]
-        public void MessageHasToBeBrokenUp()
+        public async Task MessageHasToBeBrokenUp()
         {
             string logGroupName = "AWSNLogGroupEventSizeExceededTest";
 
@@ -64,20 +65,20 @@ namespace AWS.Logger.NLogger.Tests
             if (NotifyLoggingCompleted(logGroupName, "LASTMESSAGE"))
             {
                 DescribeLogStreamsResponse describeLogstreamsResponse =
-                Client.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
+                await Client.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
                 {
                     Descending = true,
                     LogGroupName = logGroupName,
                     OrderBy = "LastEventTime"
-                }).Result;
+                });
 
                 // Wait for the large messages to propagate
                 Thread.Sleep(5000);
-                getLogEventsResponse = Client.GetLogEventsAsync(new GetLogEventsRequest
+                getLogEventsResponse = await Client.GetLogEventsAsync(new GetLogEventsRequest
                 {
                     LogGroupName = logGroupName,
                     LogStreamName = describeLogstreamsResponse.LogStreams[0].LogStreamName
-                }).Result;
+                });
             }
             _testFixture.LogGroupNameList.Add(logGroupName);
             Assert.Equal(4, getLogEventsResponse.Events.Count);

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>AWS.Logger.SeriLog.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
  
   <ItemGroup>
@@ -35,19 +37,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
+++ b/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>AWS.Logger.TestUtils</AssemblyName>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <DebugType Condition=" '$(TargetFramework)' == 'net452' ">Full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == 'net462' ">Full</DebugType>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.305.6" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
  
 </Project>

--- a/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
+++ b/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>AWS.Logger.UnitTests</AssemblyName>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -14,17 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.UnitTests/DisableLogGroupCreationTests.cs
+++ b/test/AWS.Logger.UnitTests/DisableLogGroupCreationTests.cs
@@ -60,7 +60,7 @@ namespace AWS.Logger.UnitTests
                     core.Flush();
                 });
 
-                await Task.WhenAny(tsk, resourceNotFoundPromise.Task).ConfigureAwait(false);
+                await Task.WhenAny(tsk, resourceNotFoundPromise.Task);
                 resourceNotFoundPromise.TrySetResult(false);
                 Assert.True(await resourceNotFoundPromise.Task);
 
@@ -72,7 +72,7 @@ namespace AWS.Logger.UnitTests
                 _testFixure.LogGroupNameList.Add(logGroupName);
 
                 // wait for the flusher task to finish, which should actually proceed OK, now that we've created the expected log group.
-                await tsk.ConfigureAwait(false);
+                await tsk;
                 core.Close();
             }
         }
@@ -119,7 +119,7 @@ namespace AWS.Logger.UnitTests
                 var logGroupResponse = await client.DescribeLogGroupsAsync(new DescribeLogGroupsRequest
                 {
                     LogGroupNamePrefix = logGroupName
-                }).ConfigureAwait(false);
+                });
                 var retention = logGroupResponse.LogGroups.Find(x => x.LogGroupName == logGroupName)?.RetentionInDays;
                 Assert.Equal(3,retention);
                 core.Close();
@@ -147,7 +147,7 @@ namespace AWS.Logger.UnitTests
                 var logGroupResponse = await client.DescribeLogGroupsAsync(new DescribeLogGroupsRequest
                 {
                     LogGroupNamePrefix = logGroupName
-                }).ConfigureAwait(false);
+                });
                 var incorrectRetention = logGroupResponse.LogGroups.Find(x => x.LogGroupName == logGroupName)?.RetentionInDays;
                 Assert.Null(incorrectRetention);
                 core.Close();


### PR DESCRIPTION
*Description of changes:*
Update tests and samples to use .NET 8 and clean up all warnings in the solutions. I also added the flag to treat warnings as flags to avoid new warnings coming in the future.

Confirmed in Visual Studio solution compiles with no warnings and all tests run successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
