### PR TITLE
[UA update] chore: Update User-Agent string

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
+++ b/src/AWS.Logger.AspNetCore/AWS.Logger.AspNetCore.csproj
@@ -22,7 +22,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>3.5.0</Version>
+    <Version>3.5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.AspNetCore/AWSLoggerProvider.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reflection;
 using AWS.Logger.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -18,6 +19,9 @@ namespace AWS.Logger.AspNetCore
         private readonly AWSLoggerConfigSection _configSection;
         private readonly Func<LogLevel, object, Exception, string> _customFormatter;
         private Func<string, LogLevel, bool> _customFilter;
+
+        private static readonly string _assemblyVersion = typeof(AWSLoggerProvider).GetTypeInfo().Assembly.GetName().Version?.ToString() ?? string.Empty;
+        private static readonly string _userAgentString = $"aws-logger-aspnetcore#{_assemblyVersion}";
 
         // Constants
         private const string DEFAULT_CATEGORY_NAME = "Default";
@@ -52,7 +56,7 @@ namespace AWS.Logger.AspNetCore
         public AWSLoggerProvider(AWSLoggerConfig config, Func<string, LogLevel, bool> filter, Func<LogLevel, object, Exception, string> formatter = null)
         {
             _scopeProvider = NullExternalScopeProvider.Instance;
-            _core = new AWSLoggerCore(config, "ILogger");
+            _core = new AWSLoggerCore(config, _userAgentString);
             _customFilter = filter;
             _customFormatter = formatter;
         }
@@ -76,7 +80,7 @@ namespace AWS.Logger.AspNetCore
         {
             _scopeProvider = configSection.IncludeScopes ? new LoggerExternalScopeProvider() : NullExternalScopeProvider.Instance;
             _configSection = configSection;
-            _core = new AWSLoggerCore(_configSection.Config, "ILogger");
+            _core = new AWSLoggerCore(_configSection.Config, _userAgentString);
         }        
 
         /// <summary>

--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -23,7 +23,7 @@
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.0.5" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.305.15" />
   </ItemGroup>
 
 </Project>

--- a/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
+++ b/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
@@ -22,7 +22,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>3.5.0</Version>
+    <Version>3.5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -5,6 +5,7 @@ using log4net.Core;
 
 using Amazon.Runtime;
 using AWS.Logger.Core;
+using System.Reflection;
 
 namespace AWS.Logger.Log4net
 {
@@ -15,6 +16,9 @@ namespace AWS.Logger.Log4net
     {
         private readonly AWSLoggerConfig _config = new AWSLoggerConfig();
         AWSLoggerCore _core = null;
+
+        private static readonly string _assemblyVersion = typeof(AWSAppender).GetTypeInfo().Assembly.GetName().Version?.ToString() ?? string.Empty;
+        private static readonly string _userAgentString = $"aws-logger-log4net#{_assemblyVersion}";
 
         /// <summary>
         /// Default Constructor
@@ -251,7 +255,7 @@ namespace AWS.Logger.Log4net
                 _core = null;
             }
 
-            _core = new AWSLoggerCore(_config, "Log4net");
+            _core = new AWSLoggerCore(_config, _userAgentString);
         }
 
         /// <summary>

--- a/src/AWS.Logger.SeriLog/AWS.Logger.SeriLog.csproj
+++ b/src/AWS.Logger.SeriLog/AWS.Logger.SeriLog.csproj
@@ -22,7 +22,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.SeriLog/AWSSink.cs
+++ b/src/AWS.Logger.SeriLog/AWSSink.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using AWS.Logger.Core;
 using Serilog;
 using Serilog.Core;
@@ -17,6 +18,9 @@ namespace AWS.Logger.SeriLog
         IFormatProvider _iformatDriver;
         ITextFormatter _textFormatter;
 
+        private static readonly string _assemblyVersion = typeof(AWSSink).GetTypeInfo().Assembly.GetName().Version?.ToString() ?? string.Empty;
+        private static readonly string _userAgentString = $"aws-logger-serilog#{_assemblyVersion}";
+
         /// <summary>
         /// Default constructor
         /// </summary>
@@ -29,7 +33,7 @@ namespace AWS.Logger.SeriLog
         /// </summary>
         public AWSSink(AWSLoggerConfig loggerConfiguration, IFormatProvider iFormatProvider = null, ITextFormatter textFormatter = null)
         {
-            _core = new AWSLoggerCore(loggerConfiguration, "SeriLogger");
+            _core = new AWSLoggerCore(loggerConfiguration, _userAgentString);
             _iformatDriver = iFormatProvider;
             _textFormatter = textFormatter;
         }

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -8,6 +8,7 @@ using NLog.Config;
 using AWS.Logger;
 using AWS.Logger.Core;
 using Amazon.Runtime;
+using System.Reflection;
 
 namespace NLog.AWS.Logger
 {
@@ -19,6 +20,9 @@ namespace NLog.AWS.Logger
     {
         AWSLoggerConfig _config = new AWSLoggerConfig();
         AWSLoggerCore _core = null;
+
+        private static readonly string _assemblyVersion = typeof(AWSTarget).GetTypeInfo().Assembly.GetName().Version?.ToString() ?? string.Empty;
+        private static readonly string _userAgentString = $"aws-logger-nlog#{_assemblyVersion}";
 
         /// <summary>
         /// Default Constructor
@@ -271,7 +275,7 @@ namespace NLog.AWS.Logger
                 FlushTimeout = FlushTimeout,
                 NewLogGroupRetentionInDays = NewLogGroupRetentionInDays,
             };
-            _core = new AWSLoggerCore(config, "NLog");
+            _core = new AWSLoggerCore(config, _userAgentString);
             _core.LogLibraryAlert += AwsLogLibraryAlert;
         }
 

--- a/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
+++ b/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
@@ -23,7 +23,7 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
+++ b/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.75" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.75" />
   </ItemGroup>
 	
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.75" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
+++ b/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.75" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.75" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
+++ b/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.305.6" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.75" />
   </ItemGroup>
  
 </Project>

--- a/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
+++ b/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.75" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
*Issue #, if available:*
SDK-169882

*Description of changes:*
chore: Update User-Agent string

We have 4 separate projects in this repo each serving as a different type of logging provider.
* [AWS.Logger.AspNetCore](https://www.nuget.org/packages/AWS.Logger.AspNetCore)
* [AWS.Logger.NLog](https://www.nuget.org/packages/AWS.Logger.NLog)
* [AWS.Logger.SeriLog](https://www.nuget.org/packages/AWS.Logger.SeriLog)
* [AWS.Logger.Log4net](https://www.nuget.org/packages/AWS.Logger.Log4net)

They all reference [AWS.Logger.Core](https://www.nuget.org/packages/AWS.Logger.Core) and use the `AWSLoggerCore(AWSLoggerConfig config, string logType)` constructor from this package to instantiate the CloudWatch client. Each logging provider passes a different string for the `logType` parameter of the constructor which is then passed on to the UA string. **The `logType` parameter is only used in the UA string and no where else.**

This PR updates the value passed to the `logType` parameter such that it also includes the assembly version for each logging provider. 

The final UA string that get appended to the CloudWatch client is as follows: _(assembly versions are based on the version bumps performed in this PR)_.
* `lib/aws-logger-core#3.3.1.0 ft/aws-logger-aspnetcore#3.5.1.0`
* `lib/aws-logger-core#3.3.1.0 ft/aws-logger-nlog#3.3.1.0`
* `lib/aws-logger-core#3.3.1.0 ft/aws-logger-log4net#3.5.1.0`
* `lib/aws-logger-core#3.3.1.0 ft/aws-logger-serilog#3.4.1.0`

I have used the `ft/` prefix for this because customers can independently use the [AWS.Logger.Core](https://www.nuget.org/packages/AWS.Logger.Core) package to pass their own logging provider as well.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
