### PR TITLE
fix build errors

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -211,7 +211,9 @@ namespace AWS.Logger.Core
             try
             {
                 _client.Config.Validate();
+#pragma warning disable CS0618 // Type or member is obsolete
                 return _client.Config.DetermineServiceURL() ?? "Undetermined ServiceURL";
+#pragma warning restore CS0618 // Type or member is obsolete
             }
             catch (Exception ex)
             {

--- a/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
+++ b/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.66" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.79" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
*Description of changes:*
The `IClientConfig.DetermineServiceURL()` method has been deprecated. Since the project is configured to treat warning as errors, the build fails.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
