### PR TITLE
ci: Add AWS CI workflow for running unit and integ tests

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -1,0 +1,46 @@
+name: AWS CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - dev
+      - 'feature/**'
+
+permissions:
+  id-token: write
+
+jobs:
+  run-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
+        with:
+          role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
+      - name: Invoke Load Balancer Lambda
+        id: lambda
+        shell: pwsh
+        run: |
+          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Roles": "${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}", "ProjectName": "${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}", "Branch": "${{ github.sha }}"}'
+          $roleArn=$(cat ./response.json)
+          "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
+      - name: Configure Test Runner Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
+        with:
+          role-to-assume: ${{ steps.lambda.outputs.roleArn }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
+      - name: Run Tests on AWS
+        id: codebuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+      - name: CodeBuild Link
+        shell: pwsh
+        run: |
+          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          echo $buildId

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -1,0 +1,25 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      dotnet: 8.x
+    commands:
+      # Mono is needed to run the tests on Linux
+      - curl https://download.mono-project.com/repo/centos8-stable.repo | tee /etc/yum.repos.d/mono-stable.repo
+      - dnf install -y mono-complete mono-devel
+  build:
+    commands:
+      - dotnet test --verbosity normal test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj --configuration Release --logger trx --results-directory ./testresults
+      - dotnet test --verbosity normal test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj --configuration Release --logger trx --results-directory ./testresults
+reports:
+    aws-dotnet-messaging-tests:
+        file-format: VisualStudioTrx
+        files:
+            - '**/*'
+        base-directory: './testresults'


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7478

*Description of changes:*
* Add AWS CI workflow for running unit and integ tests (I needed to install mono for the tests to run on linux)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
