### PR TITLE
Exposes AmazonCloudWatchLogsConfig.AuthenticationRegion property.

### DIFF
--- a/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
+++ b/src/AWS.Logger.AspNetCore/AWSLoggerConfigSection.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Extensions.Configuration
         internal const string LIBRARY_LOG_FILE_NAME = "LibraryLogFileName";
         internal const string LIBRARY_LOG_ERRORS = "LibraryLogErrors";
         internal const string FLUSH_TIMEOUT = "FlushTimeout";
+        internal const string AUTHENTICATION_REGION = "AuthenticationRegion";
 
         private const string INCLUDE_LOG_LEVEL_KEY = "IncludeLogLevel";
         private const string INCLUDE_CATEGORY_KEY = "IncludeCategory";
@@ -194,6 +195,10 @@ namespace Microsoft.Extensions.Configuration
             if (loggerConfigSection[FLUSH_TIMEOUT] != null)
             {
                 Config.FlushTimeout = TimeSpan.FromMilliseconds(Int32.Parse(loggerConfigSection[FLUSH_TIMEOUT]));
+            }
+            if (loggerConfigSection[AUTHENTICATION_REGION] != null)
+            {
+                Config.AuthenticationRegion = loggerConfigSection[AUTHENTICATION_REGION];
             }
 
             if (loggerConfigSection[INCLUDE_LOG_LEVEL_KEY] != null)

--- a/src/AWS.Logger.Core/AWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/AWSLoggerConfig.cs
@@ -209,5 +209,11 @@ namespace AWS.Logger
         /// </para>
         /// </summary>
         public TimeSpan FlushTimeout { get; set; } = TimeSpan.FromMilliseconds(30000);
+
+        /// <summary>
+        /// Gets and sets the AuthenticationRegion property. Used in AWS4 request signing, this is an optional property; 
+        /// change it only if the region cannot be determined from the service endpoint.
+        /// </summary>
+        public string AuthenticationRegion { get; set; }
     }
 }

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -97,6 +97,11 @@ namespace AWS.Logger.Core
                 }
             }
 
+            if (!string.IsNullOrEmpty(_config.AuthenticationRegion))
+            {
+                awsConfig.AuthenticationRegion = _config.AuthenticationRegion;
+            }
+
             var credentials = DetermineCredentials(config);
             _client = new AmazonCloudWatchLogsClient(credentials, awsConfig);
 

--- a/src/AWS.Logger.Core/IAWSLoggerConfig.cs
+++ b/src/AWS.Logger.Core/IAWSLoggerConfig.cs
@@ -157,5 +157,11 @@ namespace AWS.Logger
         /// </para>
         /// </summary>
         TimeSpan FlushTimeout { get; }
+
+        /// <summary>
+        /// Gets and sets the AuthenticationRegion property. Used in AWS4 request signing, this is an optional property; 
+        /// change it only if the region cannot be determined from the service endpoint.
+        /// </summary>
+        string AuthenticationRegion { get; set; }
     }
 }

--- a/src/AWS.Logger.Log4net/AWSAppender.cs
+++ b/src/AWS.Logger.Log4net/AWSAppender.cs
@@ -245,6 +245,16 @@ namespace AWS.Logger.Log4net
         }
 
         /// <summary>
+        /// Gets and sets the AuthenticationRegion property. Used in AWS4 request signing, this is an optional property; 
+        /// change it only if the region cannot be determined from the service endpoint.
+        /// </summary>
+        public string AuthenticationRegion
+        {
+            get { return _config.AuthenticationRegion; }
+            set { _config.AuthenticationRegion = value; }
+        }
+
+        /// <summary>
         /// Initialize the appender based on the options set.
         /// </summary>
         public override void ActivateOptions()

--- a/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
+++ b/src/AWS.Logger.SeriLog/AWSLoggerSeriLogExtension.cs
@@ -28,6 +28,7 @@ namespace AWS.Logger.SeriLog
         internal const string LIBRARY_LOG_FILE_NAME = "Serilog:LibraryLogFileName";
         internal const string LIBRARY_LOG_ERRORS = "Serilog:LibraryLogErrors";
         internal const string FLUSH_TIMEOUT = "Serilog:FlushTimeout";
+        internal const string AUTHENTICATION_REGION = "Serilog:AuthenticationRegion";
 
         /// <summary>
         /// AWSSeriLogger target that is called when the customer is using 
@@ -104,6 +105,11 @@ namespace AWS.Logger.SeriLog
             {
                 config.FlushTimeout = TimeSpan.FromMilliseconds(Int32.Parse(configuration[FLUSH_TIMEOUT]));
             }
+            if (configuration[AUTHENTICATION_REGION] != null)
+            {
+                config.AuthenticationRegion = configuration[AUTHENTICATION_REGION];
+            }
+
             return AWSSeriLog(loggerConfiguration, config, iFormatProvider, textFormatter, restrictedToMinimumLevel);
         }
 

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -247,6 +247,16 @@ namespace NLog.AWS.Logger
             set { _config.FlushTimeout = value; }
         }
 
+        /// <summary>
+        /// Gets and sets the AuthenticationRegion property. Used in AWS4 request signing, this is an optional property; 
+        /// change it only if the region cannot be determined from the service endpoint.
+        /// </summary>
+        public string AuthenticationRegion
+        {
+            get { return _config.AuthenticationRegion; }
+            set { _config.AuthenticationRegion = value; }
+        }
+
         /// <inheritdoc/>
         protected override void InitializeTarget()
         {
@@ -274,6 +284,7 @@ namespace NLog.AWS.Logger
                 LibraryLogFileName = LibraryLogFileName,
                 FlushTimeout = FlushTimeout,
                 NewLogGroupRetentionInDays = NewLogGroupRetentionInDays,
+                AuthenticationRegion = AuthenticationRegion
             };
             _core = new AWSLoggerCore(config, _userAgentString);
             _core.LogLibraryAlert += AwsLogLibraryAlert;


### PR DESCRIPTION
*Issue #, if available:* #255

*Description of changes:*
Exposes `AmazonCloudWatchLogsConfig.AuthenticationRegion` property. Implementing this small change allows users to use the AWS Logger .NET for different regions than just 'us-east-1' with Localstack.
___
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
