### PR TITLE
fix: fixed issues with test suite instability

### DIFF
--- a/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
+++ b/test/AWS.Logger.AspNetCore.Tests/TestClass.cs
@@ -80,10 +80,10 @@ namespace AWS.Logger.AspNetCore.Tests
         /// 10 debug messages to CloudWatchLogs. The results are then verified.
         /// </summary>
         [Fact]
-        public void ILogger()
+        public async Task ILogger()
         {
             LoggingSetup("appsettings.json",null);
-            SimpleLoggingTest(ConfigSection.Config.LogGroup);
+            await SimpleLoggingTest(ConfigSection.Config.LogGroup);
         }
 
         [Fact]
@@ -129,10 +129,10 @@ namespace AWS.Logger.AspNetCore.Tests
         /// threads that log 200 debug messages each to CloudWatchLogs. The results are then verified.
         /// </summary>
         [Fact]
-        public void MultiThreadTest()
+        public async Task MultiThreadTest()
         {
             LoggingSetup("multiThreadTest.json",null);
-            MultiThreadTestGroup(ConfigSection.Config.LogGroup);
+            await MultiThreadTestGroup(ConfigSection.Config.LogGroup);
         }
 
         /// <summary>
@@ -143,17 +143,17 @@ namespace AWS.Logger.AspNetCore.Tests
         /// inorder to force a buffer full scenario. The results are then verified.
         /// </summary>
         [Fact]
-        public void MultiThreadBufferFullTest()
+        public async Task MultiThreadBufferFullTest()
         {
             LoggingSetup("multiThreadBufferFullTest.json",null);
-            MultiThreadBufferFullTestGroup(ConfigSection.Config.LogGroup);
+            await MultiThreadBufferFullTestGroup(ConfigSection.Config.LogGroup);
         }
 
         [Fact]
-        public void OverrideLogStreamNameTest()
+        public async Task OverrideLogStreamNameTest()
         {
             LoggingSetup("overrideLogStreamName.json", null);
-            MultiThreadTestGroup(ConfigSection.Config.LogGroup, ConfigSection.Config.LogStreamName);
+            await MultiThreadTestGroup(ConfigSection.Config.LogGroup, ConfigSection.Config.LogStreamName);
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace AWS.Logger.AspNetCore.Tests
             Logger.LogError(0, new Exception("Exception message."), "Error message");
             for (int i = 0; i < count-2; i++)
             {
-                Logger.LogDebug(string.Format("Test logging message {0} Ilogger, Thread Id:{1}", i, Thread.CurrentThread.ManagedThreadId));
+                Logger.LogDebug(string.Format("Test logging message {0} Ilogger, Thread Id:{1}", i, Environment.CurrentManagedThreadId));
             }
             Logger.LogDebug(LASTMESSAGE);
         }

--- a/test/AWS.Logger.Log4Net.Tests/MultiThreadBufferFullTest.config
+++ b/test/AWS.Logger.Log4Net.Tests/MultiThreadBufferFullTest.config
@@ -3,7 +3,7 @@
   <!-- A1 is set to be a ConsoleAppender -->
   <appender name="MultiThreadBufferFullTest" type="AWS.Logger.Log4net.AWSAppender,AWS.Logger.Log4net" >
 
-    <LogGroup>AWSLog4NetGroupMultiThreadBufferFullTest</LogGroup>
+    <LogGroup>{LOG_GROUP_NAME}</LogGroup>
     <Region>us-west-2</Region>
     <MaxQueuedMessages>10</MaxQueuedMessages>
 

--- a/test/AWS.Logger.Log4Net.Tests/MultiThreadTest.config
+++ b/test/AWS.Logger.Log4Net.Tests/MultiThreadTest.config
@@ -3,7 +3,7 @@
   <!-- A1 is set to be a ConsoleAppender -->
   <appender name="MultiThreadTest" type="AWS.Logger.Log4net.AWSAppender,AWS.Logger.Log4net" >
 
-    <LogGroup>AWSLog4NetGroupLog4NetMultiThreadTest</LogGroup>
+    <LogGroup>{LOG_GROUP_NAME}</LogGroup>
     <Region>us-west-2</Region>
 
     <layout type="log4net.Layout.PatternLayout">

--- a/test/AWS.Logger.Log4Net.Tests/OverrideLogStreamName.config
+++ b/test/AWS.Logger.Log4Net.Tests/OverrideLogStreamName.config
@@ -4,7 +4,7 @@
   <!-- A1 is set to be a ConsoleAppender -->
   <appender name="OverrideLogStreamName" type="AWS.Logger.Log4net.AWSAppender,AWS.Logger.Log4net" >
 
-    <LogGroup>AWSLog4NetGroupOverrideLogStreamName</LogGroup>
+    <LogGroup>{LOG_GROUP_NAME}</LogGroup>
     <LogStreamName>CustomStreamName</LogStreamName>
     <Region>us-west-2</Region>
     <LogStreamNameSuffix>Custom</LogStreamNameSuffix> <!-- should be ignored since LogStreamName is set -->

--- a/test/AWS.Logger.Log4Net.Tests/Properties/AssemblyInfo.cs
+++ b/test/AWS.Logger.Log4Net.Tests/Properties/AssemblyInfo.cs
@@ -29,3 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/test/AWS.Logger.Log4Net.Tests/log4net.config
+++ b/test/AWS.Logger.Log4Net.Tests/log4net.config
@@ -4,7 +4,7 @@
   <!-- A1 is set to be a ConsoleAppender -->
   <appender name="AWS" type="AWS.Logger.Log4net.AWSAppender,AWS.Logger.Log4net" >
 
-    <LogGroup>AWSLog4NetGroupLog4Net</LogGroup>
+    <LogGroup>{LOG_GROUP_NAME}</LogGroup>
     <Region>us-west-2</Region>
     <LogStreamNameSuffix>Custom</LogStreamNameSuffix>
     <LogStreamNamePrefix>CustomPrefix</LogStreamNamePrefix>

--- a/test/AWS.Logger.NLog.Tests/AWSNLogGroupEventSizeExceededTest.config
+++ b/test/AWS.Logger.NLog.Tests/AWSNLogGroupEventSizeExceededTest.config
@@ -5,10 +5,10 @@
     <add assembly ="NLog.AWS.Logger"/>
   </extensions>
   <targets>
-    <target name="AWSNLogGroupEventSizeExceededTest" type="AWSTarget" logGroup="AWSNLogGroupEventSizeExceededTest" region="us-west-2" logStreamNameSuffix="Custom"/>
+    <target name="{LOG_GROUP_NAME}" type="AWSTarget" logGroup="{LOG_GROUP_NAME}" region="us-west-2" logStreamNameSuffix="Custom"/>
     <target name="loggerRegular" xsi:type="Console" layout="${callsite} ${message}" />
   </targets>
   <rules>
-    <logger name="loggerRegularEventSizeExceeded" minlevel="Debug" writeTo="loggerRegular,AWSNLogGroupEventSizeExceededTest"/>
+    <logger name="loggerRegularEventSizeExceeded" minlevel="Debug" writeTo="loggerRegular,{LOG_GROUP_NAME}"/>
   </rules>
 </nlog>

--- a/test/AWS.Logger.NLog.Tests/AWSNLogGroupMultiThreadBufferFullTest.config
+++ b/test/AWS.Logger.NLog.Tests/AWSNLogGroupMultiThreadBufferFullTest.config
@@ -5,10 +5,10 @@
     <add assembly ="NLog.AWS.Logger"/>
   </extensions>
   <targets>
-    <target name="AWSNLogGroupMultiThreadBufferFullTest" type="AWSTarget" logGroup="AWSNLogGroupMultiThreadBufferFullTest" region="us-west-2" MaxQueuedMessages="10"/>
+    <target name="{LOG_GROUP_NAME}" type="AWSTarget" logGroup="{LOG_GROUP_NAME}" region="us-west-2" MaxQueuedMessages="10"/>
     <target name="loggerRegular" xsi:type="Console" layout="${callsite} ${message}" />
   </targets>
   <rules>
-    <logger name="loggerMultiThreadBufferFull" minlevel="Debug" writeTo="loggerRegular,AWSNLogGroupMultiThreadBufferFullTest" />
+    <logger name="loggerMultiThreadBufferFull" minlevel="Debug" writeTo="loggerRegular,{LOG_GROUP_NAME}" />
   </rules>
 </nlog>

--- a/test/AWS.Logger.NLog.Tests/AWSNLogGroupMultiThreadTest.config
+++ b/test/AWS.Logger.NLog.Tests/AWSNLogGroupMultiThreadTest.config
@@ -5,10 +5,10 @@
     <add assembly ="NLog.AWS.Logger"/>
   </extensions>
   <targets>
-    <target name="AWSNLogGroupMultiThreadTest" type="AWSTarget" logGroup="AWSNLogGroupMultiThreadTest" region="us-west-2"/>
+    <target name="{LOG_GROUP_NAME}" type="AWSTarget" logGroup="{LOG_GROUP_NAME}" region="us-west-2"/>
     <target name="loggerRegular" xsi:type="Console" layout="${callsite} ${message}" />
   </targets>
   <rules>
-    <logger name="loggerMultiThread" minlevel="Debug" writeTo="loggerRegular,AWSNLogGroupMultiThreadTest" />
+    <logger name="loggerMultiThread" minlevel="Debug" writeTo="loggerRegular,{LOG_GROUP_NAME}" />
   </rules>
 </nlog>

--- a/test/AWS.Logger.NLog.Tests/AWSNLogOverrideLogStreamName.config
+++ b/test/AWS.Logger.NLog.Tests/AWSNLogOverrideLogStreamName.config
@@ -5,10 +5,10 @@
     <add assembly ="NLog.AWS.Logger"/>
   </extensions>
   <targets>
-    <target name="AWSNLogOverrideLogStreamName" type="AWSTarget" logGroup="AWSNLogOverrideLogStreamName" region="us-west-2" logStreamNameSuffix="Custom" logStreamNamePrefix="CustomPrefix" logStreamName="CustomStreamName"/>
+    <target name="{LOG_GROUP_NAME}" type="AWSTarget" logGroup="{LOG_GROUP_NAME}" region="us-west-2" logStreamNameSuffix="Custom" logStreamNamePrefix="CustomPrefix" logStreamName="CustomStreamName"/>
     <target name="overrideLogStreamName" xsi:type="Console" layout="${callsite} ${message}" />
   </targets>
   <rules>
-    <logger name="overrideLogStreamName" minlevel="Debug" writeTo="overrideLogStreamName,AWSNLogOverrideLogStreamName"/>
+    <logger name="overrideLogStreamName" minlevel="Debug" writeTo="overrideLogStreamName,{LOG_GROUP_NAME}"/>
   </rules>
 </nlog>

--- a/test/AWS.Logger.NLog.Tests/Regular.config
+++ b/test/AWS.Logger.NLog.Tests/Regular.config
@@ -5,10 +5,10 @@
     <add assembly ="NLog.AWS.Logger"/>
   </extensions>
   <targets>
-    <target name="AWSNLogGroup" type="AWSTarget" logGroup="AWSNLogGroup" region="us-west-2" logStreamNameSuffix="Custom" logStreamNamePrefix="CustomPrefix"/>
+    <target name="{LOG_GROUP_NAME}" type="AWSTarget" logGroup="{LOG_GROUP_NAME}" region="us-west-2" logStreamNameSuffix="Custom" logStreamNamePrefix="CustomPrefix"/>
     <target name="loggerRegular" xsi:type="Console" layout="${callsite} ${message}" />
   </targets>
   <rules>
-    <logger name="loggerRegular" minlevel="Debug" writeTo="loggerRegular,AWSNLogGroup"/>
+    <logger name="loggerRegular" minlevel="Debug" writeTo="loggerRegular,{LOG_GROUP_NAME}"/>
   </rules>
 </nlog>

--- a/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroup.json
+++ b/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroup.json
@@ -2,7 +2,7 @@
   "Serilog": {
     "Using": [ "AWS.Logger.SeriLog" ],
     "MinimumLevel": "Debug",
-    "LogGroup": "AWSSeriLogGroup",
+    "LogGroup": "{LOG_GROUP_NAME}",
     "Region": "us-west-2",
     "LogStreamNameSuffix": "Custom",
     "LogStreamNamePrefix": "CustomPrefix",

--- a/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupMultiThreadBufferFullTest.json
+++ b/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupMultiThreadBufferFullTest.json
@@ -2,7 +2,7 @@
   "Serilog": {
     "Using": [ "AWS.Logger.SeriLog" ],
     "MinimumLevel": "Debug",
-    "LogGroup": "AWSSeriLogGroupMultiThreadBufferFullTest",
+    "LogGroup": "{LOG_GROUP_NAME}",
     "Region": "us-west-2",
     "LogStreamNameSuffix": "Custom",
     "MaxQueuedMessages": "100",

--- a/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupMultiThreadTest.json
+++ b/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupMultiThreadTest.json
@@ -2,7 +2,7 @@
   "Serilog": {
     "Using": [ "AWS.Logger.SeriLog" ],
     "MinimumLevel": "Debug",
-    "LogGroup": "AWSSeriLogGroupMultiThreadTest",
+    "LogGroup": "{LOG_GROUP_NAME}",
     "Region": "us-west-2",
     "LogStreamNameSuffix": "Custom",
     "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]

--- a/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupOverrideLogStreamName.json
+++ b/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupOverrideLogStreamName.json
@@ -2,7 +2,7 @@
   "Serilog": {
     "Using": [ "AWS.Logger.SeriLog" ],
     "MinimumLevel": "Debug",
-    "LogGroup": "AWSSeriLogGroupOverrideLogStreamName",
+    "LogGroup": "{LOG_GROUP_NAME}",
     "Region": "us-west-2",
     "LogStreamName": "CustomLogStream",
     "LogStreamNameSuffix": "Custom",

--- a/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupRestrictedToMinimumLevel.json
+++ b/test/AWS.Logger.SeriLog.Tests/AWSSeriLogGroupRestrictedToMinimumLevel.json
@@ -2,7 +2,7 @@
   "Serilog": {
     "Using": [ "AWS.Logger.SeriLog" ],
     "MinimumLevel": "Debug",
-    "LogGroup": "AWSSeriLogGroupRestrictedtoMinimumLevel",
+    "LogGroup": "{LOG_GROUP_NAME}",
     "Region": "us-west-2",
     "LogStreamNameSuffix": "Custom",
     "LogStreamNamePrefix": "CustomPrefix",

--- a/test/AWS.Logger.TestUtils/BaseTestClass.cs
+++ b/test/AWS.Logger.TestUtils/BaseTestClass.cs
@@ -1,11 +1,8 @@
-﻿using Amazon.CloudWatchLogs;
-using Amazon.CloudWatchLogs.Model;
+﻿using Amazon.CloudWatchLogs.Model;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,41 +18,39 @@ namespace AWS.Logger.TestUtils
         public const string CUSTOMSTREAMSUFFIX = "Custom";
         public const string CUSTOMSTREAMPREFIX = "CustomPrefix";
         public TestFixture _testFixture;
-        public AmazonCloudWatchLogsClient Client;
 
         public BaseTestClass(TestFixture testFixture)
         {
             _testFixture = testFixture;
-            Client = new AmazonCloudWatchLogsClient(Amazon.RegionEndpoint.USWest2);
         }
 
-        protected bool NotifyLoggingCompleted(string logGroupName, string filterPattern)
+        protected async Task<bool> NotifyLoggingCompleted(string logGroupName, string filterPattern)
         {
             Stopwatch timer = new Stopwatch();
             timer.Start();
             while (timer.Elapsed < TimeSpan.FromSeconds(THREAD_WAITTIME))
             {
-                Thread.Sleep(500);
-                if (FilterPatternExists(logGroupName, filterPattern))
+                await Task.Delay(500);
+                if (await FilterPatternExists(logGroupName, filterPattern))
                 {
                     break;
                 }
             }
-            return FilterPatternExists(logGroupName, filterPattern);
+            return await FilterPatternExists(logGroupName, filterPattern);
         }
 
-        protected bool FilterPatternExists(string logGroupName, string filterPattern)
+        protected async Task<bool> FilterPatternExists(string logGroupName, string filterPattern)
         {
             DescribeLogStreamsResponse describeLogstreamsResponse;
             try
             {
-                describeLogstreamsResponse = Client.
+                describeLogstreamsResponse = await _testFixture.Client.
                     DescribeLogStreamsAsync(new DescribeLogStreamsRequest
                     {
                         Descending = true,
                         LogGroupName = logGroupName,
                         OrderBy = "LastEventTime"
-                    }).Result;
+                    });
             }
             catch (Exception) {
                 return false;
@@ -63,15 +58,13 @@ namespace AWS.Logger.TestUtils
             
             if (describeLogstreamsResponse.LogStreams.Count > 0)
             {
-                List<string> logStreamNames = new List<string>();
-                logStreamNames.Add(describeLogstreamsResponse.LogStreams[0].LogStreamName);
-                FilterLogEventsResponse filterLogEventsResponse = Client.
+                FilterLogEventsResponse filterLogEventsResponse = await _testFixture.Client.
                     FilterLogEventsAsync(new FilterLogEventsRequest
                     {
                         FilterPattern = filterPattern,
                         LogGroupName = logGroupName,
-                        LogStreamNames = logStreamNames
-                    }).Result;
+                        LogStreamNames = new List<string> { describeLogstreamsResponse.LogStreams[0].LogStreamName }
+                    });
 
                 return filterLogEventsResponse.Events.Count > 0;
             }
@@ -83,33 +76,32 @@ namespace AWS.Logger.TestUtils
 
         protected abstract void LogMessages(int count);
 
-        protected void SimpleLoggingTest(string logGroupName)
+        protected async Task SimpleLoggingTest(string logGroupName)
         {
             LogMessages(SIMPLELOGTEST_COUNT);
             GetLogEventsResponse getLogEventsResponse = new GetLogEventsResponse();
-            if (NotifyLoggingCompleted(logGroupName, "LASTMESSAGE"))
+            if (await NotifyLoggingCompleted(logGroupName, "LASTMESSAGE"))
             {
-                DescribeLogStreamsResponse describeLogstreamsResponse =
-                                                        Client.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
-                                                        {
-                                                            Descending = true,
-                                                            LogGroupName = logGroupName,
-                                                            OrderBy = "LastEventTime"
-                                                        }).Result;
-
-                
-                getLogEventsResponse = Client.GetLogEventsAsync(new GetLogEventsRequest
+                var describeLogstreamsResponse = await _testFixture.Client.DescribeLogStreamsAsync(
+                    new DescribeLogStreamsRequest
+                    {
+                        Descending = true,
+                        LogGroupName = logGroupName,
+                        OrderBy = "LastEventTime"
+                    });
+                var logStream = describeLogstreamsResponse.LogStreams.First();
+                getLogEventsResponse = await _testFixture.Client.GetLogEventsAsync(new GetLogEventsRequest
                 {
                     LogGroupName = logGroupName,
-                    LogStreamName = describeLogstreamsResponse.LogStreams[0].LogStreamName
-                }).Result;
+                    LogStreamName = logStream.LogStreamName
+                });
 
-                var customStreamSuffix = describeLogstreamsResponse.LogStreams[0].LogStreamName.Split('-').Last().Trim();
+                var customStreamSuffix = logStream.LogStreamName.Split('-').Last().Trim();
                 Assert.Equal(CUSTOMSTREAMSUFFIX, customStreamSuffix);
-                var customStreamPrefix = describeLogstreamsResponse.LogStreams[0].LogStreamName.Split('-').First().Trim();
+                var customStreamPrefix = logStream.LogStreamName.Split('-').First().Trim();
                 Assert.Equal(CUSTOMSTREAMPREFIX, customStreamPrefix);
             }
-            Assert.Equal(SIMPLELOGTEST_COUNT, getLogEventsResponse.Events.Count());
+            Assert.Equal(SIMPLELOGTEST_COUNT, getLogEventsResponse.Events.Count);
 
 
             _testFixture.LogGroupNameList.Add(logGroupName);
@@ -125,7 +117,7 @@ namespace AWS.Logger.TestUtils
         /// May be used when overriding the stream name as opposed to using the 
         /// generated name based on the prefix and suffix.
         /// </param>
-        protected void MultiThreadTestGroup(string logGroupName, string expectedLogStreamName = "")
+        protected async Task MultiThreadTestGroup(string logGroupName, string expectedLogStreamName = "")
         {
             // This allows the fixture to delete the group at the end,
             // whether or not the test passes
@@ -137,22 +129,21 @@ namespace AWS.Logger.TestUtils
             var totalCount = 0;
             for (int i = 0; i < THREAD_COUNT; i++)
             {
-                tasks.Add(Task.Factory.StartNew(() => LogMessages(count)));
+                tasks.Add(Task.Run(() => LogMessages(count)));
                 totalCount = totalCount + count;
             }
 
-
-            Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(THREAD_WAITTIME));
+            await Task.WhenAll(tasks.ToArray());
             int testCount = -1;
-            if (NotifyLoggingCompleted(logGroupName, "LASTMESSAGE"))
+            if (await NotifyLoggingCompleted(logGroupName, "LASTMESSAGE"))
             {
                 DescribeLogStreamsResponse describeLogstreamsResponse =
-                Client.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
+                await _testFixture.Client.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
                 {
                     Descending = true,
                     LogGroupName = logGroupName,
                     OrderBy = "LastEventTime"
-                }).Result;
+                });
 
                 if (describeLogstreamsResponse.LogStreams.Count > 0)
                 {
@@ -164,19 +155,16 @@ namespace AWS.Logger.TestUtils
                         Assert.Equal(expectedLogStreamName, describeLogstreamsResponse.LogStreams[0].LogStreamName);
                     }
                     testCount = 0;
-                    foreach (var logStream in describeLogstreamsResponse.LogStreams)
-                    {
-                        GetLogEventsResponse getLogEventsResponse =
-                            Client.GetLogEventsAsync(new GetLogEventsRequest
+                    GetLogEventsResponse getLogEventsResponse =
+                            await _testFixture.Client.GetLogEventsAsync(new GetLogEventsRequest
                             {
                                 LogGroupName = logGroupName,
-                                LogStreamName = logStream.LogStreamName
-                            }).Result;
+                                LogStreamName = describeLogstreamsResponse.LogStreams[0].LogStreamName
+                            });
 
-                        if (getLogEventsResponse != null)
-                        {
-                            testCount += getLogEventsResponse.Events.Count();
-                        }
+                    if (getLogEventsResponse != null)
+                    {
+                        testCount += getLogEventsResponse.Events.Count;
                     }
                 }
             }
@@ -184,7 +172,7 @@ namespace AWS.Logger.TestUtils
             Assert.Equal(totalCount, testCount);
         }
 
-        protected void MultiThreadBufferFullTestGroup(string logGroupName)
+        protected async Task MultiThreadBufferFullTestGroup(string logGroupName)
         {
             var tasks = new List<Task>();
             var streamNames = new List<string>();
@@ -192,11 +180,11 @@ namespace AWS.Logger.TestUtils
             var totalCount = 0;
             for (int i = 0; i < THREAD_COUNT; i++)
             {
-                tasks.Add(Task.Factory.StartNew(() => LogMessages(count)));
+                tasks.Add(Task.Run(() => LogMessages(count)));
                 totalCount = totalCount + count;
             }
-            Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(THREAD_WAITTIME));
-            Assert.True(NotifyLoggingCompleted(logGroupName, "maximum"));
+            await Task.WhenAll(tasks.ToArray());
+            Assert.True(await NotifyLoggingCompleted(logGroupName, "maximum"));
 
             _testFixture.LogGroupNameList.Add(logGroupName);
         }


### PR DESCRIPTION
*Description of changes:*
The tests in the release pipeline have been consistently failing due to stability issues. The tests interfere with each other and are not properly set up to run in parallel. Given that the test projects target multiple frameworks, the test runs affect each other even if tests within a certain class run sequentially. This PR applies multiple fixes to the tests to ensure a stable and consistent run.
* Updated log group names to contain unique elements. This was the main issue since several tests publish to a log group with the same name. This affected event count assertions and test cleanup.
* Updated function calls to use async/await
* Updated certain threading calls to more recent versions of those calls. Task.Factory.StartNew -> Task.Run, Thread.Sleep -> Task.Delay, etc ...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
