### PR TITLE
AWSTarget updated to NLog v5.2.2 for build trimming

### DIFF
--- a/samples/NLog/ConfigExample/ConfigExample.csproj
+++ b/samples/NLog/ConfigExample/ConfigExample.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\..\src\NLog.AWS.Logger\NLog.AWS.Logger.csproj" />
   </ItemGroup>
 

--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -26,6 +26,8 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <EnableTrimAnalyzer Condition=" '$(TargetFramework)' == 'net8.0' ">true</EnableTrimAnalyzer>
+        <IsTrimmable Condition=" '$(TargetFramework)' == 'net8.0' ">true</IsTrimmable>
         
         <Version>4.0.0</Version>
     </PropertyGroup>

--- a/src/NLog.AWS.Logger/AWSTarget.cs
+++ b/src/NLog.AWS.Logger/AWSTarget.cs
@@ -29,7 +29,6 @@ namespace NLog.AWS.Logger
         /// </summary>
         public AWSTarget()
         {
-            this.OptimizeBufferReuse = true;
         }
 
         /// <summary>

--- a/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
+++ b/src/NLog.AWS.Logger/NLog.AWS.Logger.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
@@ -26,6 +26,9 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+      
+        <EnableTrimAnalyzer Condition=" '$(TargetFramework)' == 'net8.0' ">true</EnableTrimAnalyzer>
+        <IsTrimmable Condition=" '$(TargetFramework)' == 'net8.0' ">true</IsTrimmable>
         
         <Version>4.0.0</Version>
     </PropertyGroup>
@@ -45,7 +48,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="NLog" Version="4.5.0" />
+        <PackageReference Include="NLog" Version="5.2.2" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 


### PR DESCRIPTION
NLog v5.2.2 supports build-trimming without build-warnings (enabled by default with .NET7 and newer)