### PR TITLE
Included original exception when failed to write to local log file

### DIFF
--- a/.autover/changes/4f814b3b-ab80-4f05-8ceb-fa1d14903c09.json
+++ b/.autover/changes/4f814b3b-ab80-4f05-8ceb-fa1d14903c09.json
@@ -1,0 +1,40 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Logger.Core",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "When failed to write to local log file write the original exception that triggered the reason for writing to the local log file to the console",
+		"Updated AWSSDK.CloudWatchLogs dependency to version 4.0.8.4"
+      ]
+    },
+    {
+      "Name": "AWS.Logger.AspNetCore",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of AWS.Logger.Core"
+      ]
+    },
+    {
+      "Name": "AWS.Logger.Log4net",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of AWS.Logger.Core"
+      ]
+    },
+    {
+      "Name": "AWS.Logger.SeriLog",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of AWS.Logger.Core"
+      ]
+    },
+    {
+      "Name": "NLog.AWS.Logger",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to latest version of AWS.Logger.Core"
+      ]
+    }	
+  ]
+}

--- a/samples/AspNetCore/ConsoleSample/ConsoleSample.csproj
+++ b/samples/AspNetCore/ConsoleSample/ConsoleSample.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.0.32" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
 

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.0.32" />
     <PackageReference Include="log4net" Version="2.0.15" />
   </ItemGroup>
 

--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -41,7 +41,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.0" />
+        <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.8.4" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -678,10 +678,10 @@ namespace AWS.Logger.Core
         {
             var userAgentString = $"{_baseUserAgentString} ft/{_logType}";
             var args = e as Amazon.Runtime.WebServiceRequestEventArgs;
-            if (args == null || !args.Headers.ContainsKey(UserAgentHeader) || args.Headers[UserAgentHeader].Contains(userAgentString))
+            if (args == null)
                 return;
 
-            args.Headers[UserAgentHeader] = args.Headers[UserAgentHeader] + " " + userAgentString;
+            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)args.Request).UserAgentDetails.AddUserAgentComponent(userAgentString);
         }
 
         void ServiceClienExceptionEvent(object sender, ExceptionEventArgs e)
@@ -705,7 +705,7 @@ namespace AWS.Logger.Core
         /// <summary>
         /// Write Exception details to the file specified with the filename
         /// </summary>
-        public static void LogLibraryError(Exception ex, string LibraryLogFileName)
+        public static void LogLibraryError(Exception originalException, string LibraryLogFileName)
         {
             try
             {
@@ -714,13 +714,14 @@ namespace AWS.Logger.Core
                     w.WriteLine("Log Entry : ");
                     w.WriteLine("{0}", DateTime.Now.ToString());
                     w.WriteLine("  :");
-                    w.WriteLine("  :{0}", ex.ToString());
+                    w.WriteLine("  :{0}", originalException.ToString());
                     w.WriteLine("-------------------------------");
                 }
             }
             catch (Exception e)
             {
                 Console.WriteLine("Exception caught when writing error log to file" + e.ToString());
+                Console.WriteLine("Original Exception attempted to be written to the log file: " + originalException.ToString());
             }
         }
     }

--- a/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
+++ b/test/AWS.Logger.AspNetCore.Tests/AWS.Logger.AspNetCore.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
 	
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
+++ b/test/AWS.Logger.NLog.FilterTests/AWS.Logger.NLog.FilterTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
+++ b/test/AWS.Logger.NLog.Tests/AWS.Logger.NLog.Tests.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
+++ b/test/AWS.Logger.SeriLog.Tests/AWS.Logger.SeriLog.Tests.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
 
 </Project>

--- a/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
+++ b/test/AWS.Logger.TestUtils/AWS.Logger.TestUtils.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="4.0.8.4" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
  
 </Project>

--- a/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
+++ b/test/AWS.Logger.UnitTests/AWS.Logger.UnitTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <!-- This needs to be referenced to allow testing via AssumeRole credentials -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.2.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/aws/aws-logging-dotnet/issues/329

*Description of changes:*
When there is a misconfiguration or connection issue sending request to CloudWatch Logs the library will write to a local log file to allow users to understand something went wrong with the exception of what happen. If you are in Lambda or some other read only file system the library then fails to write to the local file. Before this patch it would write to the console the exception for why it couldn't write to the local file. This PR adds to the console write to also include the original exception that triggered the need to ever write to the local log file.

I also updated to latest AWS SDK for .NET versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
