### PR TITLE
Remove out of date packagerefence

### DIFF
--- a/samples/NLog/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
+++ b/samples/NLog/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\..\src\NLog.AWS.Logger\NLog.AWS.Logger.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
*Description of changes:*
Release build failed because the sample project was reference 4.5.0 but the NLog appender is referencing 5.2.2 triggering a downgrade warning. And since warnings are treated as errors the release build fail. Since the sample project is referencing our NLog appender which already has a dependency on NLog we don't need this package reference on the sample at all. So to make maintenance easier in the future I removed the reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
