### PR TITLE
Update log4net from 2.0.15 to 3.3.0 across all projects

### DIFF
--- a/.autover/changes/bump-log4net-3.3.0.json
+++ b/.autover/changes/bump-log4net-3.3.0.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Logger.Log4net",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Updated log4net dependency from 2.0.15 to 3.3.0 to resolve moderate severity vulnerability (GHSA-4f7c-pmjv-c25w)"
+      ]
+    }
+  ]
+}

--- a/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
+++ b/samples/Log4net/BasicAWSCredentialsConfigurationExample/BasicAWSCredentialsConfigurationExample.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="4.0.3.6" />
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Log4net/ConfigExample/ConfigExample.csproj
+++ b/samples/Log4net/ConfigExample/ConfigExample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Log4net/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
+++ b/samples/Log4net/ProgrammaticConfigurationExample/ProgrammaticConfigurationExample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
+++ b/src/AWS.Logger.Log4net/AWS.Logger.Log4net.csproj
@@ -44,7 +44,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="log4net" Version="2.0.15" />
+        <PackageReference Include="log4net" Version="3.3.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
+++ b/test/AWS.Logger.Log4Net.FilterTests/AWS.Logger.Log4Net.FilterTests.csproj
@@ -24,6 +24,6 @@
   </ItemGroup>
 	
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="3.3.0" />
   </ItemGroup>
 </Project>

--- a/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
+++ b/test/AWS.Logger.Log4Net.Tests/AWS.Logger.Log4Net.Tests.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="3.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves moderate severity vulnerability GHSA-4f7c-pmjv-c25w. Updated log4net references in src, test, and sample projects. Added autover change file for minor version bump.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
