### PR TITLE
Avoid infinite log resending if exceptions happen during the log-sending process

### DIFF
--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -27,7 +27,7 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         
-        <Version>4.0.2</Version>
+        <Version>4.0.3</Version>
     </PropertyGroup>
     
     <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/AWS.Logger.Core/AWS.Logger.Core.csproj
+++ b/src/AWS.Logger.Core/AWS.Logger.Core.csproj
@@ -27,7 +27,7 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         
-        <Version>4.0.3</Version>
+        <Version>4.0.2</Version>
     </PropertyGroup>
     
     <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -2,6 +2,8 @@
 using Amazon.CloudWatchLogs.Model;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
+using Amazon.Runtime.Credentials;
+using Amazon.Runtime.Internal;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -11,7 +13,6 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Amazon.Runtime.Credentials;
 
 namespace AWS.Logger.Core
 {
@@ -448,24 +449,22 @@ namespace AWS.Logger.Core
                 DateTime latestLogDateTime = _repo._request.LogEvents.Last().Timestamp ?? DateTime.UtcNow;
                 //avoid the error that the log events should be in a 24 hours range
                 //https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
-                while (_repo._request.LogEvents.Count > 0)
+                int lastInvalidEventIndexToRemove = -1;
+                for (int i = 0; i < _repo._request.LogEvents.Count; i++)
                 {
-                    var firstTimestamp = _repo._request.LogEvents.First().Timestamp;
-                    if (!firstTimestamp.HasValue)
+                    var logEvent = _repo._request.LogEvents[i];
+                    if (!logEvent.Timestamp.HasValue || (latestLogDateTime - logEvent.Timestamp.Value) > MaxLogEventBatchAllowedTimeRange)
                     {
-                        // Skip events with null timestamps or remove them
-                        _repo.RemoveMessageAt(0);
-                        continue;
-                    }
-
-                    if ((latestLogDateTime - firstTimestamp.Value) > MaxLogEventBatchAllowedTimeRange)
-                    {
-                        _repo.RemoveMessageAt(0);
+                        lastInvalidEventIndexToRemove = i;
                     }
                     else
                     {
-                        break; // Events are within the allowed time range, so we can stop checking
+                        break; // Events are in order, so we can stop checking once we find a valid event
                     }
+                }
+                if (lastInvalidEventIndexToRemove >= 0)
+                {
+                    _repo.RemoveMessages(0, lastInvalidEventIndexToRemove + 1);
                 }
             }
         }
@@ -714,16 +713,19 @@ namespace AWS.Logger.Core
                 _request.LogEvents.Add(ev);
             }
 
-            public void RemoveMessageAt(int index)
+            public void RemoveMessages(int startIndex, int count)
             {
-                if (index < 0 || index >= _request.LogEvents.Count)
+                if (startIndex < 0 || startIndex >= _request.LogEvents.Count || count < 0 || (startIndex + count) > _request.LogEvents.Count)
                 {
                     return;
                 }
                 Encoding unicode = Encoding.Unicode;
-                InputLogEvent ev = _request.LogEvents[index];
-                _totalMessageSize -= unicode.GetMaxByteCount(ev.Message.Length);
-                _request.LogEvents.RemoveAt(index);
+                for (int i = startIndex; i < startIndex + count; i++)
+                {
+                    InputLogEvent ev = _request.LogEvents[i];
+                    _totalMessageSize -= unicode.GetMaxByteCount(ev.Message.Length);
+                }
+                _request.LogEvents.RemoveRange(startIndex, count);
             }
 
             public void Reset()

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -2,8 +2,6 @@
 using Amazon.CloudWatchLogs.Model;
 using Amazon.Runtime;
 using Amazon.Runtime.CredentialManagement;
-using Amazon.Runtime.Credentials;
-using Amazon.Runtime.Internal;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -13,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime.Credentials;
 
 namespace AWS.Logger.Core
 {

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -430,11 +430,9 @@ namespace AWS.Logger.Core
                 }
                 catch (Exception ex)
                 {
-                    //drop logs in sending batch since those logs may cause exceptions
-                    _repo.Reset();
                     // We don't want to kill the main monitor loop. We will simply log the error, then continue.
                     // If it is an OperationCancelledException, die
-                    LogLibraryServiceError(new Exception("Logs in the sending batch are dropped because of exceptions", ex));
+                    LogLibraryServiceError(ex);
                 }
             }
         }

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -446,7 +446,7 @@ namespace AWS.Logger.Core
             if (_repo._request.LogEvents.Count > 0)
             {
                 DateTime latestLogDateTime = _repo._request.LogEvents.Last().Timestamp ?? DateTime.UtcNow;
-                //avoid the error that the log events should be in a 24 hours range
+                //Avoid the error that log events must be within a 24-hour window.
                 //https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
                 int lastInvalidEventIndexToRemove = -1;
                 for (int i = 0; i < _repo._request.LogEvents.Count; i++)

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -485,7 +485,6 @@ namespace AWS.Logger.Core
         {
             try
             {
-                //Make sure the log events are in the right order.
                 PrepareLogEventBatchForSending();
                 var response = await _client.Value.PutLogEventsAsync(_repo._request, token).ConfigureAwait(false);
                 _repo.Reset();

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -447,13 +447,9 @@ namespace AWS.Logger.Core
                 ev1.Timestamp.GetValueOrDefault().CompareTo(ev2.Timestamp.GetValueOrDefault()));
             if (_repo._request.LogEvents.Count > 0)
             {
-                DateTime? latestLogDateTime = _repo._request.LogEvents.Last().Timestamp;
-                if (!latestLogDateTime.HasValue)
-                {
-                    latestLogDateTime = DateTime.UtcNow;
-                }
+                DateTime latestLogDateTime = _repo._request.LogEvents.Last().Timestamp ?? DateTime.UtcNow;
                 //avoid the error that the log events should be in a 24 hours range
-                //https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/put_log_events.html#put-log-events
+                //https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
                 while (_repo._request.LogEvents.Count > 0)
                 {
                     var firstTimestamp = _repo._request.LogEvents.First().Timestamp;

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -493,6 +493,12 @@ namespace AWS.Logger.Core
 
                 _currentStreamName = await LogEventTransmissionSetup(token).ConfigureAwait(false);
             }
+            catch (InvalidParameterException ex)
+            {
+                // Bad log events with timestamp/range issues, log error and discard batch
+                LogLibraryServiceError(ex);
+                _repo.Reset();
+            }
         }
 
         /// <summary>

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -106,7 +106,6 @@ namespace AWS.Logger.Core
                     {
                         awsConfig.UseHttp = true;
                     }
-                    awsConfig.AuthenticationRegion = _config.Region;
                 }
                 else
                 {
@@ -440,9 +439,10 @@ namespace AWS.Logger.Core
             }
         }
 
+        private static readonly TimeSpan MaxLogEventBatchAllowedTimeRange = TimeSpan.FromHours(24);
         private void PrepareLogEventBatchForSending()
         {
-            //Make sure the log events are in the right order.
+            //Make sure the log events are in order from the oldest to the newest.
             _repo._request.LogEvents.Sort((ev1, ev2) =>
                 ev1.Timestamp.GetValueOrDefault().CompareTo(ev2.Timestamp.GetValueOrDefault()));
             if (_repo._request.LogEvents.Count > 0)
@@ -464,13 +464,13 @@ namespace AWS.Logger.Core
                         continue;
                     }
 
-                    if ((latestLogDateTime - firstTimestamp.Value) > TimeSpan.FromHours(24))
+                    if ((latestLogDateTime - firstTimestamp.Value) > MaxLogEventBatchAllowedTimeRange)
                     {
                         _repo.RemoveMessageAt(0);
                     }
                     else
                     {
-                        break; // Events are sorted, so we can stop checking
+                        break; // Events are within the allowed time range, so we can stop checking
                     }
                 }
             }
@@ -486,7 +486,7 @@ namespace AWS.Logger.Core
             try
             {
                 PrepareLogEventBatchForSending();
-                var response = await _client.Value.PutLogEventsAsync(_repo._request, token).ConfigureAwait(false);
+                await _client.Value.PutLogEventsAsync(_repo._request, token).ConfigureAwait(false);
                 _repo.Reset();
             }
             catch (ResourceNotFoundException ex)

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -106,6 +106,7 @@ namespace AWS.Logger.Core
                     {
                         awsConfig.UseHttp = true;
                     }
+                    awsConfig.AuthenticationRegion = _config.Region;
                 }
                 else
                 {
@@ -430,9 +431,47 @@ namespace AWS.Logger.Core
                 }
                 catch (Exception ex)
                 {
+                    //drop logs in sending batch since those logs may cause exceptions
+                    _repo.Reset();
                     // We don't want to kill the main monitor loop. We will simply log the error, then continue.
                     // If it is an OperationCancelledException, die
-                    LogLibraryServiceError(ex);
+                    LogLibraryServiceError(new Exception("Logs in the sending batch are dropped because of exceptions", ex));
+                }
+            }
+        }
+
+        private void PrepareLogEventBatchForSending()
+        {
+            //Make sure the log events are in the right order.
+            _repo._request.LogEvents.Sort((ev1, ev2) =>
+                ev1.Timestamp.GetValueOrDefault().CompareTo(ev2.Timestamp.GetValueOrDefault()));
+            if (_repo._request.LogEvents.Count > 0)
+            {
+                DateTime? latestLogDateTime = _repo._request.LogEvents.Last().Timestamp;
+                if (!latestLogDateTime.HasValue)
+                {
+                    latestLogDateTime = DateTime.UtcNow;
+                }
+                //avoid the error that the log events should be in a 24 hours range
+                //https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/put_log_events.html#put-log-events
+                while (_repo._request.LogEvents.Count > 0)
+                {
+                    var firstTimestamp = _repo._request.LogEvents.First().Timestamp;
+                    if (!firstTimestamp.HasValue)
+                    {
+                        // Skip events with null timestamps or remove them
+                        _repo.RemoveMessageAt(0);
+                        continue;
+                    }
+
+                    if ((latestLogDateTime - firstTimestamp.Value) > TimeSpan.FromHours(24))
+                    {
+                        _repo.RemoveMessageAt(0);
+                    }
+                    else
+                    {
+                        break; // Events are sorted, so we can stop checking
+                    }
                 }
             }
         }
@@ -447,8 +486,7 @@ namespace AWS.Logger.Core
             try
             {
                 //Make sure the log events are in the right order.
-                _repo._request.LogEvents.Sort((ev1, ev2) => 
-                    ev1.Timestamp.GetValueOrDefault().CompareTo(ev2.Timestamp.GetValueOrDefault()));
+                PrepareLogEventBatchForSending();
                 var response = await _client.Value.PutLogEventsAsync(_repo._request, token).ConfigureAwait(false);
                 _repo.Reset();
             }
@@ -681,6 +719,18 @@ namespace AWS.Logger.Core
                 Encoding unicode = Encoding.Unicode;
                 _totalMessageSize += unicode.GetMaxByteCount(ev.Message.Length);
                 _request.LogEvents.Add(ev);
+            }
+
+            public void RemoveMessageAt(int index)
+            {
+                if (index < 0 || index >= _request.LogEvents.Count)
+                {
+                    return;
+                }
+                Encoding unicode = Encoding.Unicode;
+                InputLogEvent ev = _request.LogEvents[index];
+                _totalMessageSize -= unicode.GetMaxByteCount(ev.Message.Length);
+                _request.LogEvents.RemoveAt(index);
             }
 
             public void Reset()

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -446,7 +446,7 @@ namespace AWS.Logger.Core
             if (_repo._request.LogEvents.Count > 0)
             {
                 DateTime latestLogDateTime = _repo._request.LogEvents.Last().Timestamp ?? DateTime.UtcNow;
-                //Avoid the error that log events must be within a 24-hour window.
+                //avoid the error that the log events should be in a 24 hours range
                 //https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
                 int lastInvalidEventIndexToRemove = -1;
                 for (int i = 0; i < _repo._request.LogEvents.Count; i++)

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -478,6 +478,11 @@ namespace AWS.Logger.Core
             try
             {
                 PrepareLogEventBatchForSending();
+                if (_repo._request.LogEvents == null || _repo._request.LogEvents.Count == 0)
+                {
+                    _repo.Reset();
+                    return;
+                }
                 await _client.Value.PutLogEventsAsync(_repo._request, token).ConfigureAwait(false);
                 _repo.Reset();
             }

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -478,7 +478,7 @@ namespace AWS.Logger.Core
             try
             {
                 PrepareLogEventBatchForSending();
-                if (_repo._request.LogEvents == null || _repo._request.LogEvents.Count == 0)
+                if (_repo._request.LogEvents.Count == 0)
                 {
                     _repo.Reset();
                     return;
@@ -495,7 +495,7 @@ namespace AWS.Logger.Core
             }
             catch (InvalidParameterException ex)
             {
-                // Bad log events with timestamp/range issues, log error and discard batch
+                // Bad log events, log error and discard batch
                 LogLibraryServiceError(ex);
                 _repo.Reset();
             }


### PR DESCRIPTION
*Issue #, if available:*
This is a PR which replaces https://github.com/aws/aws-logging-dotnet/pull/219 with the latest dev branch

*Description of changes:*
We drop the logs in the log batch if the current log batch causes exceptions in the log-sending process 
We did this because we observed that our log batch causes the [over 24 hours spanning problem ](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/put_log_events.html#put-log-events)
and since the monitor is not stopped, it just resends the log batch forever.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
